### PR TITLE
Initial skeleton for Evaluator classes and exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # eval
 
+![Lint](https://github.com/instructlab/eval/actions/workflows/lint.yml/badge.svg?branch=main)
+![Build](https://github.com/instructlab/eval/actions/workflows/pypi.yaml/badge.svg?branch=main)
+![Release](https://img.shields.io/github/v/release/instructlab/eval)
+![License](https://img.shields.io/github/license/instructlab/eval)
+
 Python library for Evaluation

--- a/src/instructlab/eval/evaluator.py
+++ b/src/instructlab/eval/evaluator.py
@@ -11,6 +11,3 @@ class Evaluator:
 
     def __init__(self, model: str) -> None:
         self.model = model
-
-    def run(self) -> dict:
-        return {}

--- a/src/instructlab/eval/evaluator.py
+++ b/src/instructlab/eval/evaluator.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+class Evaluator:
+    """
+    Parent class for Evaluators
+    """
+
+    def __init__(self, model) -> None:
+        self.model = model
+
+    def run(self) -> dict:
+        return {}

--- a/src/instructlab/eval/evaluator.py
+++ b/src/instructlab/eval/evaluator.py
@@ -4,9 +4,12 @@
 class Evaluator:
     """
     Parent class for Evaluators
+
+    Atttributes:
+        model   The model to be evaluated
     """
 
-    def __init__(self, model) -> None:
+    def __init__(self, model: str) -> None:
         self.model = model
 
     def run(self) -> dict:

--- a/src/instructlab/eval/evaluator.py
+++ b/src/instructlab/eval/evaluator.py
@@ -6,8 +6,8 @@ class Evaluator:
     Parent class for Evaluators
 
     Atttributes:
-        model   The model to be evaluated
+        model_path   Path to the model to be evaluated
     """
 
-    def __init__(self, model: str) -> None:
-        self.model = model
+    def __init__(self, model_path: str) -> None:
+        self.model_path = model_path

--- a/src/instructlab/eval/exceptions.py
+++ b/src/instructlab/eval/exceptions.py
@@ -10,6 +10,9 @@ class EvalError(Exception):
 class ModelNotFoundError(EvalError):
     """
     Exception raised when model is not able to be found
+
+    Attributes
+        model   model that is being operated on
     """
 
     def __init__(self, model) -> None:

--- a/src/instructlab/eval/exceptions.py
+++ b/src/instructlab/eval/exceptions.py
@@ -12,10 +12,13 @@ class ModelNotFoundError(EvalError):
     Exception raised when model is not able to be found
 
     Attributes
-        model   model that is being operated on
+        message     error message to be printed on raise
+        model       model that is being operated on
+        path        filepath of model location
     """
 
-    def __init__(self, model) -> None:
+    def __init__(self, path) -> None:
         super().__init__()
-        self.model = model
-        self.message = f"Model {self.model} could not be found"
+        self.path = path
+        self.model = path.rsplit("/")[-1]
+        self.message = f"Model {self.model} could not be found at {self.path}"

--- a/src/instructlab/eval/exceptions.py
+++ b/src/instructlab/eval/exceptions.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+class EvalError(Exception):
+    """
+    Parent class for all of instructlab-eval exceptions
+    """
+
+
+class ModelNotFoundError(EvalError):
+    """
+    Exception raised when model is not able to be found
+    """
+
+    def __init__(self, model) -> None:
+        super().__init__()
+        self.model = model
+        self.message = f"Model {self.model} could not be found"

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -22,14 +22,10 @@ class MMLU_Evaluator(Evaluator):
         self.few_shots = few_shots
         self.batch_size = batch_size
 
-    def run(self) -> dict:
+    def run(self) -> tuple:
         individual_scores: dict[str, float] = {}
         overall_score: float = 0.0
-        payload = {
-            "individual_scores": individual_scores,
-            "overall_score": overall_score,
-        }
-        return payload
+        return overall_score, individual_scores
 
 
 class PR_MMLU_Evaluator(Evaluator):
@@ -39,8 +35,8 @@ class PR_MMLU_Evaluator(Evaluator):
     Attributes:
         sdg_path    path where all the PR MMLU tasks are stored
         task        group name that is shared by all the PR MMLU tasks
-        few_shots    number of examples
-        batch_size   number of GPUs
+        few_shots   number of examples
+        batch_size  number of GPUs
     """
 
     def __init__(
@@ -57,13 +53,8 @@ class PR_MMLU_Evaluator(Evaluator):
         self.few_shots = few_shots
         self.batch_size = batch_size
 
-    def run(self) -> dict:
+    def run(self) -> tuple:
         individual_scores: dict[str, float] = {}
         overall_score: float = 0.0
         qa_pairs: list[tuple] = []
-        payload = {
-            "individual_scores": individual_scores,
-            "overall_score": overall_score,
-            "qa_pairs": qa_pairs,
-        }
-        return payload
+        return overall_score, individual_scores, qa_pairs

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -4,7 +4,7 @@
 from .evaluator import Evaluator
 
 
-class MMLUEvaluator(Evaluator):
+class MMLU_Evaluator(Evaluator):
     """
     Child class of an Evaluator for Massive Multitask Language Understanding (MMLU)
     """
@@ -12,5 +12,20 @@ class MMLUEvaluator(Evaluator):
     def __init__(self, model, tasks: list[str], fewshots: int, batchsize: int) -> None:
         super().__init__(model)
         self.tasks = tasks
+        self.fewshots = fewshots
+        self.batchsize = batchsize
+
+
+class PR_MMLU_Evaluator(Evaluator):
+    """
+    Child class of an Evaluator for PR Massive Multitask Language Understanding (PR MMLU)
+    """
+
+    def __init__(
+        self, model, task: str, sdg_path: str, fewshots: int, batchsize: int
+    ) -> None:
+        super().__init__(model)
+        self.task = task
+        self.sdg_path = sdg_path
         self.fewshots = fewshots
         self.batchsize = batchsize

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -9,7 +9,7 @@ class MMLU_Evaluator(Evaluator):
     Child class of an Evaluator for Massive Multitask Language Understanding (MMLU)
 
     Attributes:
-        tasks       list of tasks for MMLU to test the model with
+        tasks        list of tasks for MMLU to test the model with
         few_shots    number of examples
         batch_size   number of GPUs
     """
@@ -23,6 +23,13 @@ class MMLU_Evaluator(Evaluator):
         self.batch_size = batch_size
 
     def run(self) -> tuple:
+        """
+        Runs MMLU evaluation
+
+        Returns:
+            overall_score       MMLU score for the overall model evaluation
+            individual_scores   Individual MMLU score for each task
+        """
         individual_scores: dict[str, float] = {}
         overall_score: float = 0.0
         return overall_score, individual_scores
@@ -54,6 +61,14 @@ class PR_MMLU_Evaluator(Evaluator):
         self.batch_size = batch_size
 
     def run(self) -> tuple:
+        """
+        Runs PR MMLU evaluation
+
+        Returns:
+            overall_score       PR MMLU score for the overall model evaluation
+            individual_scores   Individual PR MMLU scores for each task
+            qa_pairs            Question and answer pairs from the evaluation
+        """
         individual_scores: dict[str, float] = {}
         overall_score: float = 0.0
         qa_pairs: list[tuple] = []

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -10,17 +10,17 @@ class MMLU_Evaluator(Evaluator):
 
     Attributes:
         tasks       list of tasks for MMLU to test the model with
-        fewshots    number of examples
-        batchsize   number of GPUs
+        few_shots    number of examples
+        batch_size   number of GPUs
     """
 
     def __init__(
-        self, model_path, tasks: list[str], fewshots: int = 2, batchsize: int = 5
+        self, model_path, tasks: list[str], few_shots: int = 2, batch_size: int = 5
     ) -> None:
         super().__init__(model_path)
         self.tasks = tasks
-        self.fewshots = fewshots
-        self.batchsize = batchsize
+        self.few_shots = few_shots
+        self.batch_size = batch_size
 
     def run(self) -> dict:
         individual_scores: dict[str, float] = {}
@@ -39,8 +39,8 @@ class PR_MMLU_Evaluator(Evaluator):
     Attributes:
         sdg_path    path where all the PR MMLU tasks are stored
         task        group name that is shared by all the PR MMLU tasks
-        fewshots    number of examples
-        batchsize   number of GPUs
+        few_shots    number of examples
+        batch_size   number of GPUs
     """
 
     def __init__(
@@ -48,14 +48,14 @@ class PR_MMLU_Evaluator(Evaluator):
         model_path,
         sdg_path: str,
         task: str = "mmlu_pr",
-        fewshots: int = 2,
-        batchsize: int = 5,
+        few_shots: int = 2,
+        batch_size: int = 5,
     ) -> None:
         super().__init__(model_path)
         self.sdg_path = sdg_path
         self.task = task
-        self.fewshots = fewshots
-        self.batchsize = batchsize
+        self.few_shots = few_shots
+        self.batch_size = batch_size
 
     def run(self) -> dict:
         individual_scores: dict[str, float] = {}

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Local
+from .evaluator import Evaluator
+
+
+class MMLUEvaluator(Evaluator):
+    """
+    Child class of an Evaluator for Massive Multitask Language Understanding (MMLU)
+    """
+
+    def __init__(self, model, tasks: list[str], fewshots: int, batchsize: int) -> None:
+        super().__init__(model)
+        self.tasks = tasks
+        self.fewshots = fewshots
+        self.batchsize = batchsize

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -7,9 +7,16 @@ from .evaluator import Evaluator
 class MMLU_Evaluator(Evaluator):
     """
     Child class of an Evaluator for Massive Multitask Language Understanding (MMLU)
+
+    Attributes:
+        tasks       list of tasks for MMLU to test the model with
+        fewshots    number of examples
+        batchsize   number of GPUs
     """
 
-    def __init__(self, model, tasks: list[str], fewshots: int, batchsize: int) -> None:
+    def __init__(
+        self, model, tasks: list[str], fewshots: int = 2, batchsize: int = 5
+    ) -> None:
         super().__init__(model)
         self.tasks = tasks
         self.fewshots = fewshots
@@ -19,13 +26,24 @@ class MMLU_Evaluator(Evaluator):
 class PR_MMLU_Evaluator(Evaluator):
     """
     Child class of an Evaluator for PR Massive Multitask Language Understanding (PR MMLU)
+
+    Attributes:
+        sdg_path    path where all the PR MMLU tasks are stored
+        task        group name that is shared by all the PR MMLU tasks
+        fewshots    number of examples
+        batchsize   number of GPUs
     """
 
     def __init__(
-        self, model, task: str, sdg_path: str, fewshots: int, batchsize: int
+        self,
+        model,
+        sdg_path: str,
+        task: str = "mmlu_pr",
+        fewshots: int = 2,
+        batchsize: int = 5,
     ) -> None:
         super().__init__(model)
-        self.task = task
         self.sdg_path = sdg_path
+        self.task = task
         self.fewshots = fewshots
         self.batchsize = batchsize

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -22,6 +22,15 @@ class MMLU_Evaluator(Evaluator):
         self.fewshots = fewshots
         self.batchsize = batchsize
 
+    def run(self) -> dict:
+        individual_scores: dict[str, float] = {}
+        overall_score: float = 0.0
+        payload = {
+            "individual_scores": individual_scores,
+            "overall_score": overall_score,
+        }
+        return payload
+
 
 class PR_MMLU_Evaluator(Evaluator):
     """
@@ -47,3 +56,14 @@ class PR_MMLU_Evaluator(Evaluator):
         self.task = task
         self.fewshots = fewshots
         self.batchsize = batchsize
+
+    def run(self) -> dict:
+        individual_scores: dict[str, float] = {}
+        overall_score: float = 0.0
+        qa_pairs: list[tuple] = []
+        payload = {
+            "individual_scores": individual_scores,
+            "overall_score": overall_score,
+            "qa_pairs": qa_pairs,
+        }
+        return payload

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -15,9 +15,9 @@ class MMLU_Evaluator(Evaluator):
     """
 
     def __init__(
-        self, model, tasks: list[str], fewshots: int = 2, batchsize: int = 5
+        self, model_path, tasks: list[str], fewshots: int = 2, batchsize: int = 5
     ) -> None:
-        super().__init__(model)
+        super().__init__(model_path)
         self.tasks = tasks
         self.fewshots = fewshots
         self.batchsize = batchsize
@@ -45,13 +45,13 @@ class PR_MMLU_Evaluator(Evaluator):
 
     def __init__(
         self,
-        model,
+        model_path,
         sdg_path: str,
         task: str = "mmlu_pr",
         fewshots: int = 2,
         batchsize: int = 5,
     ) -> None:
-        super().__init__(model)
+        super().__init__(model_path)
         self.sdg_path = sdg_path
         self.task = task
         self.fewshots = fewshots

--- a/src/instructlab/eval/mtbench.py
+++ b/src/instructlab/eval/mtbench.py
@@ -7,6 +7,9 @@ from .evaluator import Evaluator
 class MT_Bench_Evaluator(Evaluator):
     """
     Child class of an Evaluator for Multi-turn Benchmark (MT-Bench)
+
+    Attributes
+        server  vLLM server endpoint
     """
 
     def __init__(self, model, server: str) -> None:
@@ -17,6 +20,10 @@ class MT_Bench_Evaluator(Evaluator):
 class PR_Bench_Evaluator(Evaluator):
     """
     Child class of an Evaluator for PR-Bench Benchmark (PR-Bench)
+
+    Attributes
+        server      vLLM server endpoint
+        questions   questions to be asked
     """
 
     def __init__(self, model, server: str, questions: str) -> None:

--- a/src/instructlab/eval/mtbench.py
+++ b/src/instructlab/eval/mtbench.py
@@ -12,8 +12,8 @@ class MT_Bench_Evaluator(Evaluator):
         server_url  vLLM server endpoint
     """
 
-    def __init__(self, model, server_url: str) -> None:
-        super().__init__(model)
+    def __init__(self, model_path, server_url: str) -> None:
+        super().__init__(model_path)
         self.server_url = server_url
 
     def run(self) -> dict:
@@ -32,8 +32,8 @@ class PR_Bench_Evaluator(Evaluator):
         questions   questions to be asked
     """
 
-    def __init__(self, model, server_url: str, questions: str) -> None:
-        super().__init__(model)
+    def __init__(self, model_path, server_url: str, questions: str) -> None:
+        super().__init__(model_path)
         self.server_url = server_url
         self.questions = questions
 

--- a/src/instructlab/eval/mtbench.py
+++ b/src/instructlab/eval/mtbench.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Local
+from .evaluator import Evaluator
+
+
+class MTBenchEvaluator(Evaluator):
+    """
+    Child class of an Evaluator for Multi-turn Benchmark (MT-Bench)
+    """
+
+    def __init__(self, model, server: str) -> None:
+        super().__init__(model)
+        self.server = server

--- a/src/instructlab/eval/mtbench.py
+++ b/src/instructlab/eval/mtbench.py
@@ -9,12 +9,12 @@ class MT_Bench_Evaluator(Evaluator):
     Child class of an Evaluator for Multi-turn Benchmark (MT-Bench)
 
     Attributes
-        server  vLLM server endpoint
+        server_url  vLLM server endpoint
     """
 
-    def __init__(self, model, server: str) -> None:
+    def __init__(self, model, server_url: str) -> None:
         super().__init__(model)
-        self.server = server
+        self.server_url = server_url
 
 
 class PR_Bench_Evaluator(Evaluator):
@@ -22,11 +22,11 @@ class PR_Bench_Evaluator(Evaluator):
     Child class of an Evaluator for PR-Bench Benchmark (PR-Bench)
 
     Attributes
-        server      vLLM server endpoint
+        server_url  vLLM server endpoint
         questions   questions to be asked
     """
 
-    def __init__(self, model, server: str, questions: str) -> None:
+    def __init__(self, model, server_url: str, questions: str) -> None:
         super().__init__(model)
-        self.server = server
+        self.server_url = server_url
         self.questions = questions

--- a/src/instructlab/eval/mtbench.py
+++ b/src/instructlab/eval/mtbench.py
@@ -17,6 +17,13 @@ class MT_Bench_Evaluator(Evaluator):
         self.server_url = server_url
 
     def run(self) -> tuple:
+        """
+        Runs MT-Bench evaluation
+
+        Returns:
+            overall_score   MT-Bench score for the overall model evaluation
+            qa_pairs        Question and answer pairs from the evaluation
+        """
         overall_score: float = 0.0
         qa_pairs: list[tuple] = []
         return overall_score, qa_pairs
@@ -37,6 +44,13 @@ class PR_Bench_Evaluator(Evaluator):
         self.questions = questions
 
     def run(self) -> tuple:
+        """
+        Runs PR-Bench evaluation
+
+        Returns:
+            overall_score   MT-Bench score for the overall model evaluation
+            qa_pairs        Question and answer pairs from the evaluation
+        """
         overall_score = 0.0
         qa_pairs: list[tuple] = []
         return overall_score, qa_pairs

--- a/src/instructlab/eval/mtbench.py
+++ b/src/instructlab/eval/mtbench.py
@@ -16,6 +16,12 @@ class MT_Bench_Evaluator(Evaluator):
         super().__init__(model)
         self.server_url = server_url
 
+    def run(self) -> dict:
+        overall_score: float = 0.0
+        qa_pairs: list[tuple] = []
+        payload = {"overall_score": overall_score, "qa_pairs": qa_pairs}
+        return payload
+
 
 class PR_Bench_Evaluator(Evaluator):
     """
@@ -30,3 +36,9 @@ class PR_Bench_Evaluator(Evaluator):
         super().__init__(model)
         self.server_url = server_url
         self.questions = questions
+
+    def run(self) -> dict:
+        overall_score = 0.0
+        qa_pairs: list[tuple] = []
+        payload = {"overall_score": overall_score, "qa_pairs": qa_pairs}
+        return payload

--- a/src/instructlab/eval/mtbench.py
+++ b/src/instructlab/eval/mtbench.py
@@ -4,7 +4,7 @@
 from .evaluator import Evaluator
 
 
-class MTBenchEvaluator(Evaluator):
+class MT_Bench_Evaluator(Evaluator):
     """
     Child class of an Evaluator for Multi-turn Benchmark (MT-Bench)
     """
@@ -12,3 +12,14 @@ class MTBenchEvaluator(Evaluator):
     def __init__(self, model, server: str) -> None:
         super().__init__(model)
         self.server = server
+
+
+class PR_Bench_Evaluator(Evaluator):
+    """
+    Child class of an Evaluator for PR-Bench Benchmark (PR-Bench)
+    """
+
+    def __init__(self, model, server: str, questions: str) -> None:
+        super().__init__(model)
+        self.server = server
+        self.questions = questions

--- a/src/instructlab/eval/mtbench.py
+++ b/src/instructlab/eval/mtbench.py
@@ -16,11 +16,10 @@ class MT_Bench_Evaluator(Evaluator):
         super().__init__(model_path)
         self.server_url = server_url
 
-    def run(self) -> dict:
+    def run(self) -> tuple:
         overall_score: float = 0.0
         qa_pairs: list[tuple] = []
-        payload = {"overall_score": overall_score, "qa_pairs": qa_pairs}
-        return payload
+        return overall_score, qa_pairs
 
 
 class PR_Bench_Evaluator(Evaluator):
@@ -37,8 +36,7 @@ class PR_Bench_Evaluator(Evaluator):
         self.server_url = server_url
         self.questions = questions
 
-    def run(self) -> dict:
+    def run(self) -> tuple:
         overall_score = 0.0
         qa_pairs: list[tuple] = []
-        payload = {"overall_score": overall_score, "qa_pairs": qa_pairs}
-        return payload
+        return overall_score, qa_pairs


### PR DESCRIPTION
This PR introduces the `Evaluator` parent class and the `MMLUEvaluator` and `MTBenchEvaluator` child classes

It also introduces the `EvalError` parent exception class for all `eval` custom exceptions and the `ModelNotFoundError` child exception class