### PR TITLE
Implement `MMLU_Evaluator.run()`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ transformers
 accelerate
 pandas
 pandas-stubs
+lm-eval>=0.4.2

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -4,7 +4,7 @@
 import os
 
 # Third Party
-from lm_eval.evaluator import simple_evaluate
+from lm_eval.evaluator import simple_evaluate  # type: ignore
 
 # First Party
 from instructlab.eval.evaluator import Evaluator

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -27,6 +27,7 @@ class MMLUEvaluator(Evaluator):
         self.model_dtype = model_dtype
         self.few_shots = few_shots
         self.batch_size = batch_size
+        self.model_path = model_path
 
     def run(self) -> tuple:
         """
@@ -68,6 +69,7 @@ class MMLUBranchEvaluator(Evaluator):
     Child class of an Evaluator for Massive Multitask Language Understanding Branch (MMLUBranch)
 
     Attributes:
+        model_path  absolute path to or name of a huggingface model
         sdg_path    path where all the MMLUBranch tasks are stored
         task        group name that is shared by all the MMLUBranch tasks
         few_shots   number of examples
@@ -82,6 +84,7 @@ class MMLUBranchEvaluator(Evaluator):
         few_shots: int = 2,
         batch_size: int = 5,
     ) -> None:
+        super().__init__()
         self.model_path = model_path
         self.sdg_path = sdg_path
         self.task = task

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -3,6 +3,8 @@
 # Local
 from .evaluator import Evaluator
 
+# Third Party 
+from lm_eval.evaluator import simple_evaluate
 
 class MMLU_Evaluator(Evaluator):
     """
@@ -15,9 +17,11 @@ class MMLU_Evaluator(Evaluator):
     """
 
     def __init__(
-        self, model_path, tasks: list[str], few_shots: int = 2, batch_size: int = 5
+        self, model, model_args, model_path, tasks: list[str], few_shots: int = 2, batch_size: int = 5
     ) -> None:
-        self.model_path = model_path
+        super().__init__(model_path)
+        self.model = model
+        self.model_args = model_args
         self.tasks = tasks
         self.few_shots = few_shots
         self.batch_size = batch_size
@@ -32,8 +36,37 @@ class MMLU_Evaluator(Evaluator):
         """
         individual_scores: dict[str, float] = {}
         overall_score: float = 0.0
+        results = lm_eval.simple_evaluate(
+            model=self.model,
+            model_args=self.model_args,
+            tasks=self.tasks,
+            num_fewshot=self.few_shots,
+            batch_size=self.batch_size,
+            log_samples=True,
+        )
+        #TODO: see what the output of results looks like 
+        #print(results)
+        #calculate_overall_score(results)
         return overall_score, individual_scores
+    
+    def calculate_overall_score(scores):
+        pass # Placeholder for calculating overall score:
+             # overall score = (num model answered correctly / num questions)
 
+############# Testing Code Follows ##############
+def main():
+    # TODO: change this- cli uses HuggingFace to access the model 
+    model = "hf"
+    model_args = "pretrained=$MODEL_PATH,dtype=bfloat16"
+    # Path to the granite model in the aliryan vm on AWS
+    model_path = "/home/ec2-user/instructlab/models/instructlab/granite-7b-lab"
+    #TODO: all 57 tasks need to be parameterized possibly by CLI
+    tasks = "mmlu_abstract_algebra"
+    mmlu = MMLU_Evaluator(model, model_args, model_path, tasks, 2, 5)
+
+if __name__ == "__main__":
+    main()
+############# Testing Code Ends ##############
 
 class PR_MMLU_Evaluator(Evaluator):
     """

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -1,28 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Local
-from .evaluator import Evaluator
+from instructlab.eval.evaluator import Evaluator
 
 # Third Party 
 from lm_eval.evaluator import simple_evaluate
+import os
 
 class MMLU_Evaluator(Evaluator):
     """
     Child class of an Evaluator for Massive Multitask Language Understanding (MMLU)
 
     Attributes:
+        model_path   absolute path to or name of a huggingface model
         tasks        list of tasks for MMLU to test the model with
+        model_dtype  dtype of model when served
         few_shots    number of examples
         batch_size   number of GPUs
     """
 
     def __init__(
-        self, model, model_args, model_path, tasks: list[str], few_shots: int = 2, batch_size: int = 5
+        self, model_path, tasks: list[str], model_dtype = 'bfloat16', few_shots: int = 2, batch_size: int = 5
     ) -> None:
         super().__init__(model_path)
-        self.model = model
-        self.model_args = model_args
         self.tasks = tasks
+        self.model_dtype = model_dtype
         self.few_shots = few_shots
         self.batch_size = batch_size
 
@@ -34,35 +36,45 @@ class MMLU_Evaluator(Evaluator):
             overall_score       MMLU score for the overall model evaluation
             individual_scores   Individual MMLU score for each task
         """
-        individual_scores: dict[str, float] = {}
-        overall_score: float = 0.0
-        results = lm_eval.simple_evaluate(
-            model=self.model,
-            model_args=self.model_args,
+        #TODO: make this a parameter for class?
+        os.environ['TOKENIZERS_PARALLELISM'] = 'true'
+
+        individual_scores: dict = {}
+        agg_score: float = 0.0
+        model_args = "pretrained=" + self.model_path + ",dtype=" + self.model_dtype
+
+        mmlu_output = simple_evaluate(
+            model="hf",
+            model_args=model_args,
             tasks=self.tasks,
             num_fewshot=self.few_shots,
-            batch_size=self.batch_size,
-            log_samples=True,
+            batch_size=self.batch_size
         )
-        #TODO: see what the output of results looks like 
-        #print(results)
-        #calculate_overall_score(results)
+
+        results = mmlu_output["results"]
+
+        for task in self.tasks:
+            mmlu_res = results[task]
+            agg_score += float(mmlu_res['acc,none'])
+            individual_scores[task] = {}
+            individual_scores[task]['score'] = float(mmlu_res['acc,none'])
+            individual_scores[task]['stderr'] = float(mmlu_res['acc_stderr,none'])
+
+        overall_score = float(agg_score/len(self.tasks))
         return overall_score, individual_scores
     
-    def calculate_overall_score(scores):
-        pass # Placeholder for calculating overall score:
-             # overall score = (num model answered correctly / num questions)
 
 ############# Testing Code Follows ##############
 def main():
-    # TODO: change this- cli uses HuggingFace to access the model 
-    model = "hf"
-    model_args = "pretrained=$MODEL_PATH,dtype=bfloat16"
     # Path to the granite model in the aliryan vm on AWS
     model_path = "/home/ec2-user/instructlab/models/instructlab/granite-7b-lab"
     #TODO: all 57 tasks need to be parameterized possibly by CLI
-    tasks = "mmlu_abstract_algebra"
-    mmlu = MMLU_Evaluator(model, model_args, model_path, tasks, 2, 5)
+    tasks = ["mmlu_abstract_algebra","mmlu_anatomy","mmlu_astronomy"]
+    dtype = "float16"
+    mmlu = MMLU_Evaluator(model_path, tasks, dtype, 2, 5)
+    overall_score, individual_scores = mmlu.run()
+    print(overall_score)
+    print(individual_scores)
 
 if __name__ == "__main__":
     main()

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Local
+# Standard
+import os
+
+# Third Party
+from lm_eval.evaluator import simple_evaluate
+
+# First Party
 from instructlab.eval.evaluator import Evaluator
 
-# Third Party 
-from lm_eval.evaluator import simple_evaluate
-import os
 
 class MMLUEvaluator(Evaluator):
     """
@@ -20,14 +23,19 @@ class MMLUEvaluator(Evaluator):
     """
 
     def __init__(
-        self, model_path, tasks: list[str], model_dtype = 'bfloat16', few_shots: int = 2, batch_size: int = 5
+        self,
+        model_path,
+        tasks: list[str],
+        model_dtype="bfloat16",
+        few_shots: int = 2,
+        batch_size: int = 5,
     ) -> None:
-        super().__init__(model_path)
+        super().__init__()
+        self.model_path = model_path
         self.tasks = tasks
         self.model_dtype = model_dtype
         self.few_shots = few_shots
         self.batch_size = batch_size
-        self.model_path = model_path
 
     def run(self) -> tuple:
         """
@@ -37,8 +45,8 @@ class MMLUEvaluator(Evaluator):
             overall_score       MMLU score for the overall model evaluation
             individual_scores   Individual MMLU score for each task
         """
-        #TODO: make this a parameter for class?
-        os.environ['TOKENIZERS_PARALLELISM'] = 'true'
+        # TODO: make this a parameter for class?
+        os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
         individual_scores: dict = {}
         agg_score: float = 0.0
@@ -49,20 +57,21 @@ class MMLUEvaluator(Evaluator):
             model_args=model_args,
             tasks=self.tasks,
             num_fewshot=self.few_shots,
-            batch_size=self.batch_size
+            batch_size=self.batch_size,
         )
 
         results = mmlu_output["results"]
 
         for task in self.tasks:
             mmlu_res = results[task]
-            agg_score += float(mmlu_res['acc,none'])
+            agg_score += float(mmlu_res["acc,none"])
             individual_scores[task] = {}
-            individual_scores[task]['score'] = float(mmlu_res['acc,none'])
-            individual_scores[task]['stderr'] = float(mmlu_res['acc_stderr,none'])
+            individual_scores[task]["score"] = float(mmlu_res["acc,none"])
+            individual_scores[task]["stderr"] = float(mmlu_res["acc_stderr,none"])
 
-        overall_score = float(agg_score/len(self.tasks))
+        overall_score = float(agg_score / len(self.tasks))
         return overall_score, individual_scores
+
 
 class MMLUBranchEvaluator(Evaluator):
     """
@@ -84,7 +93,6 @@ class MMLUBranchEvaluator(Evaluator):
         few_shots: int = 2,
         batch_size: int = 5,
     ) -> None:
-        super().__init__()
         self.model_path = model_path
         self.sdg_path = sdg_path
         self.task = task

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -7,7 +7,7 @@ from instructlab.eval.evaluator import Evaluator
 from lm_eval.evaluator import simple_evaluate
 import os
 
-class MMLU_Evaluator(Evaluator):
+class MMLUEvaluator(Evaluator):
     """
     Child class of an Evaluator for Massive Multitask Language Understanding (MMLU)
 
@@ -62,31 +62,14 @@ class MMLU_Evaluator(Evaluator):
 
         overall_score = float(agg_score/len(self.tasks))
         return overall_score, individual_scores
-    
 
-############# Testing Code Follows ##############
-def main():
-    # Path to the granite model in the aliryan vm on AWS
-    model_path = "/home/ec2-user/instructlab/models/instructlab/granite-7b-lab"
-    #TODO: all 57 tasks need to be parameterized possibly by CLI
-    tasks = ["mmlu_abstract_algebra","mmlu_anatomy","mmlu_astronomy"]
-    dtype = "float16"
-    mmlu = MMLU_Evaluator(model_path, tasks, dtype, 2, 5)
-    overall_score, individual_scores = mmlu.run()
-    print(overall_score)
-    print(individual_scores)
-
-if __name__ == "__main__":
-    main()
-############# Testing Code Ends ##############
-
-class PR_MMLU_Evaluator(Evaluator):
+class MMLUBranchEvaluator(Evaluator):
     """
-    Child class of an Evaluator for PR Massive Multitask Language Understanding (PR MMLU)
+    Child class of an Evaluator for Massive Multitask Language Understanding Branch (MMLUBranch)
 
     Attributes:
-        sdg_path    path where all the PR MMLU tasks are stored
-        task        group name that is shared by all the PR MMLU tasks
+        sdg_path    path where all the MMLUBranch tasks are stored
+        task        group name that is shared by all the MMLUBranch tasks
         few_shots   number of examples
         batch_size  number of GPUs
     """
@@ -107,11 +90,11 @@ class PR_MMLU_Evaluator(Evaluator):
 
     def run(self) -> tuple:
         """
-        Runs PR MMLU evaluation
+        Runs MMLUBranch evaluation
 
         Returns:
-            overall_score       PR MMLU score for the overall model evaluation
-            individual_scores   Individual PR MMLU scores for each task
+            overall_score       MMLUBranch score for the overall model evaluation
+            individual_scores   Individual MMLUBranch scores for each task
             qa_pairs            Question and answer pairs from the evaluation
         """
         individual_scores: dict[str, float] = {}

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -50,7 +50,7 @@ class MMLUEvaluator(Evaluator):
 
         individual_scores: dict = {}
         agg_score: float = 0.0
-        model_args = "pretrained=" + self.model_path + ",dtype=" + self.model_dtype
+        model_args = f"pretrained= {self.model_path}, dtype= {self.model_dtype}"
 
         mmlu_output = simple_evaluate(
             model="hf",


### PR DESCRIPTION
This PR updates the MMLUEvaluator child class to include the lm-evaluation-harness lib dependency and adds an API call to simple_evaluate() to run MMLU. 

ToDo:
- [x] test running in a VM
- [x]  observe the output of results to help decide how to access individual scores vs. overall score
- [x] finish writing the helper function to calculate the overall score based on the results
- [x] parameterize these 57 tasks (I think CLI needs to do this?) https://github.com/instructlab/evaluation/blob/main/scripts/run_mmlu.sh#L24 