### PR TITLE
add cpu support for MMLU bench

### DIFF
--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -6,6 +6,7 @@ import os
 # Third Party
 from lm_eval.evaluator import simple_evaluate  # type: ignore
 from lm_eval.tasks import TaskManager  # type: ignore
+import torch
 
 # First Party
 from instructlab.eval.evaluator import Evaluator
@@ -58,6 +59,7 @@ class MMLUEvaluator(Evaluator):
             tasks=self.tasks,
             num_fewshot=self.few_shots,
             batch_size=self.batch_size,
+            device=("cuda" if torch.cuda.is_available() else "cpu"),
         )
 
         results = mmlu_output["results"]


### PR DESCRIPTION
simple_evaluate has a device option that seems to default to cuda. People with 128GB or even ~90GB+ of ram should be able to run eval on CPU. Add auto detection for if torch is available