### PR TITLE
Include task scores with mmlu results + adjust default api retries

### DIFF
--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -194,12 +194,15 @@ class MMLUBranchEvaluator(Evaluator):
         )
         results = mmlu_output["results"]
 
-        for task in self.tasks:
-            mmlu_res = results[task]
-            agg_score += float(mmlu_res["acc,none"])
-            individual_scores[task] = {}
-            individual_scores[task]["score"] = float(mmlu_res["acc,none"])
-            individual_scores[task]["stderr"] = float(mmlu_res["acc_stderr,none"])
+        for task, result in results.items():
+            if task in self.tasks:
+                agg_score += float(result["acc,none"])
+            else:
+                individual_scores[task] = {
+                    "score": float(result["acc,none"]),
+                    "stderr": float(result["acc_stderr,none"]),
+                }
 
         overall_score = float(agg_score / len(self.tasks))
+
         return overall_score, individual_scores

--- a/src/instructlab/eval/mt_bench_common.py
+++ b/src/instructlab/eval/mt_bench_common.py
@@ -17,8 +17,8 @@ from fastchat.model.model_adapter import get_conversation_template  # type: igno
 import openai
 
 # API setting constants
-API_MAX_RETRY = 16
-API_RETRY_SLEEP = 10
+API_MAX_RETRY = 4
+API_RETRY_SLEEP = 4
 API_ERROR_OUTPUT = "$ERROR$"
 
 # Categories that need reference answers


### PR DESCRIPTION
This change allows for the individual tasks to be returned to the caller to be able to show something more interesting in the output.  Previously only mmlu_pr would be returned.

I've also adjusted the api retires to something more reasonable.  I'm going to open another issue to address api errors.

Example output:
```
# KNOWLEDGE EVALUATION REPORT

## BASE MODEL
/home/ec2-user/instructlab/models/instructlab/merlinite-7b-lab

## MODEL
/home/ec2-user/instructlab/models/instructlab/granite-7b-lab

### AVERAGE:
+0.23 (across 2)

### IMPROVEMENTS
1. task2 (+0.37)

### REGRESSIONS:
1. task1 (-0.11)

### NO CHANGE:
1. tonsils
```