### PR TITLE
Allow first_n option for gen answers, fix return values with max_workers=1 and only print api errors on final failure

### DIFF
--- a/src/instructlab/eval/mt_bench_answers.py
+++ b/src/instructlab/eval/mt_bench_answers.py
@@ -116,9 +116,17 @@ def generate_answers(
     if os.path.isfile(answer_file):
         os.remove(answer_file)
 
+    first_n = None
+    first_n_env = os.environ.get("INSTRUCTLAB_EVAL_FIRST_N_QUESTIONS")
+    if first_n_env:
+        first_n = int(first_n_env)
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []
-        for question in questions:
+        for i, question in enumerate(questions):
+            if first_n is not None and i >= first_n:
+                break
+
             future = executor.submit(
                 get_answer,
                 question,

--- a/src/instructlab/eval/mt_bench_common.py
+++ b/src/instructlab/eval/mt_bench_common.py
@@ -220,7 +220,7 @@ def play_a_match_single(openai_client, match: MatchSingle, output_file: str) -> 
 
 def chat_completion_openai(openai_client, model, conv, temperature, max_tokens) -> str:
     output = API_ERROR_OUTPUT
-    for _ in range(API_MAX_RETRY):
+    for i in range(API_MAX_RETRY):
         try:
             messages = conv.to_openai_api_messages()
             if (
@@ -242,7 +242,9 @@ def chat_completion_openai(openai_client, model, conv, temperature, max_tokens) 
             output = response.choices[0].message.content
             break
         except openai.OpenAIError as e:
-            print(type(e), e)
+            if i == API_MAX_RETRY - 1:
+                # Print error on last try
+                print(type(e), e)
             time.sleep(API_RETRY_SLEEP)
 
     return output

--- a/src/instructlab/eval/mt_bench_judgment.py
+++ b/src/instructlab/eval/mt_bench_judgment.py
@@ -243,7 +243,7 @@ def judge_model(
             ):
                 pass
 
-        return question_file, output_file, answer_file
+    return question_file, output_file, answer_file
 
 
 def generate_judgment(


### PR DESCRIPTION
Three minor changes/fixes:

- INSTRUCTLAB_EVAL_FIRST_N_QUESTIONS is now supported for gen answers in addition to judgment.  This is to enable faster sniff test cycles
- Fixing an error where no result was returned for max_workers == 1.  Return was at the wrong indent level.
- Only print the failing error from api calls.