### PR TITLE
feat: Include error rate in judgment results

### DIFF
--- a/src/instructlab/eval/mt_bench.py
+++ b/src/instructlab/eval/mt_bench.py
@@ -135,7 +135,7 @@ class MTBenchBranchEvaluator(Evaluator):
         Returns:
             qa_pairs        Question and answer pairs (with scores) from the evaluation
         """
-        _, qa_pairs, _ = mt_bench_judgment.generate_judgment(
+        _, qa_pairs, _, error_rate = mt_bench_judgment.generate_judgment(
             self.model_name,
             self.judge_model_name,
             server_url,
@@ -145,4 +145,4 @@ class MTBenchBranchEvaluator(Evaluator):
             data_dir=self.output_dir,
             bench_name="mt_bench_branch",
         )
-        return qa_pairs
+        return qa_pairs, error_rate

--- a/src/instructlab/eval/mt_bench_judgment.py
+++ b/src/instructlab/eval/mt_bench_judgment.py
@@ -81,7 +81,10 @@ def make_judgment(
         judgment_file, lines=True, dtype={"question_id": str}
     )
     judgment_df = judgment_df_all[["model", "score", "turn"]]
+    judgments_len = len(judgment_df)
     judgment_df = judgment_df[judgment_df["score"] != -1]
+    error_free_judgments_len = len(judgment_df)
+    error_rate = (judgments_len - error_free_judgments_len) / judgments_len
 
     turn_scores = []
     # First turn
@@ -133,7 +136,7 @@ def make_judgment(
         if bench_name == "mt_bench_branch":
             qa_pair["qna_file"] = row["qna_file"]
         qa_pairs.append(qa_pair)
-    return overall_score, qa_pairs, turn_scores
+    return overall_score, qa_pairs, turn_scores, error_rate
 
 
 def judge_model(


### PR DESCRIPTION
Since the serving api can return errors, we need to return the error rate to the caller to be able to determine significance to result.