### PR TITLE
fix: Add specific error handling around git repo input

### DIFF
--- a/src/instructlab/eval/exceptions.py
+++ b/src/instructlab/eval/exceptions.py
@@ -13,12 +13,48 @@ class ModelNotFoundError(EvalError):
 
     Attributes
         message     error message to be printed on raise
-        model       model that is being operated on
         path        filepath of model location
     """
 
     def __init__(self, path) -> None:
         super().__init__()
-        self.path = path
-        self.model = path.rsplit("/")[-1]
-        self.message = f"Model {self.model} could not be found at {self.path}"
+        self.message = f"Model could not be found at {path}"
+
+
+class InvalidGitRepoError(EvalError):
+    """
+    Exception raised when taxonomy dir provided isn't a valid git repo
+    Attributes
+        message         error message to be printed on raise
+        taxonomy_dir    supplied taxonomy directory
+    """
+
+    def __init__(self, taxonomy_dir) -> None:
+        super().__init__()
+        self.message = f"Invalid git repo: {taxonomy_dir}"
+
+
+class GitRepoNotFoundError(EvalError):
+    """
+    Exception raised when taxonomy dir provided does not exist
+    Attributes
+        message         error message to be printed on raise
+        taxonomy_dir    supplied taxonomy directory
+    """
+
+    def __init__(self, taxonomy_dir) -> None:
+        super().__init__()
+        self.message = f"Taxonomy git repo not found: {taxonomy_dir}"
+
+
+class InvalidGitBranchError(EvalError):
+    """
+    Exception raised when branch provided is invalid
+    Attributes
+        message         error message to be printed on raise
+        branch          supplied branch
+    """
+
+    def __init__(self, branch) -> None:
+        super().__init__()
+        self.message = f"Invalid git branch: {branch}"

--- a/src/instructlab/eval/mt_bench_branch_generator.py
+++ b/src/instructlab/eval/mt_bench_branch_generator.py
@@ -12,6 +12,7 @@ import shortuuid
 import yaml
 
 # Local
+from .exceptions import GitRepoNotFoundError, InvalidGitBranchError, InvalidGitRepoError
 from .logger_config import setup_logger
 from .mt_bench_common import bench_dir
 
@@ -119,6 +120,12 @@ def generate(judge_model_name, branch, taxonomy_dir, output_dir):
             for entry in reference_answers:
                 json.dump(entry, outfile)
                 outfile.write("\n")
+    except git.exc.NoSuchPathError as nspe:
+        raise GitRepoNotFoundError(taxonomy_dir) from nspe
+    except git.exc.GitCommandError as gce:
+        raise InvalidGitBranchError(branch) from gce
+    except (git.exc.InvalidGitRepositoryError, git.exc.GitError) as ge:
+        raise InvalidGitRepoError(taxonomy_dir) from ge
     finally:
         if restore_branch is not None:
             taxonomy_repo.git.checkout(restore_branch)


### PR DESCRIPTION
Adds error handling to return specific eval errors for known errors encountered with git repos and models missing.

This fix (with a new release of eval) must go in before: https://github.com/instructlab/instructlab/pull/1616