### PR TITLE
Adding basic logging facilities for eval with a first pass at some useful logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ GitPython>=3.1.42,<4.0.0
 shortuuid
 openai>=1.13.3,<2.0.0
 psutil
+rich==13.7.1
 torch
 transformers
 accelerate

--- a/src/instructlab/eval/logger_config.py
+++ b/src/instructlab/eval/logger_config.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import logging
+
+# Third Party
+from rich.logging import RichHandler
+
+
+def setup_logger(name):
+    # Set up the logger
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler()],
+    )
+    logger = logging.getLogger(name)
+    return logger

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -11,6 +11,11 @@ import torch
 # First Party
 from instructlab.eval.evaluator import Evaluator
 
+# Local
+from .logger_config import setup_logger
+
+logger = setup_logger(__name__)
+
 MMLU_TASKS = [
     "mmlu_abstract_algebra",
     "mmlu_anatomy",
@@ -109,6 +114,7 @@ class MMLUEvaluator(Evaluator):
             overall_score       MMLU score for the overall model evaluation
             individual_scores   Individual MMLU score for each task
         """
+        logger.debug(locals())
         # TODO: make this a parameter for class?
         os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
@@ -175,6 +181,7 @@ class MMLUBranchEvaluator(Evaluator):
             overall_score       Average MMLUBranch score for the task group
             individual_scores   Individual MMLUBranch scores for each task in the task group
         """
+        logger.debug(locals())
         # TODO: make this a parameter for class?
         os.environ["TOKENIZERS_PARALLELISM"] = "true"
 

--- a/src/instructlab/eval/mt_bench.py
+++ b/src/instructlab/eval/mt_bench.py
@@ -9,6 +9,9 @@ from instructlab.eval import (
 
 # Local
 from .evaluator import Evaluator
+from .logger_config import setup_logger
+
+logger = setup_logger(__name__)
 
 
 class MTBenchEvaluator(Evaluator):
@@ -43,6 +46,7 @@ class MTBenchEvaluator(Evaluator):
         Attributes
             server_url      Model server endpoint (Ex: http://localhost:8000/v1) for the model being evaluated
         """
+        logger.debug(locals())
         mt_bench_answers.generate_answers(
             self.model_name,
             server_url,
@@ -62,6 +66,7 @@ class MTBenchEvaluator(Evaluator):
             qa_pairs        Question and answer pairs (with scores) from the evaluation
             turn_scores     A list of indexed turn scores
         """
+        logger.debug(locals())
         return mt_bench_judgment.generate_judgment(
             self.model_name,
             self.judge_model_name,
@@ -109,6 +114,7 @@ class MTBenchBranchEvaluator(Evaluator):
         Attributes
             server_url  Model server endpoint (Ex: http://localhost:8000/v1) for the model being evaluated
         """
+        logger.debug(locals())
         mt_bench_branch_generator.generate(
             self.judge_model_name,
             self.branch,
@@ -135,6 +141,7 @@ class MTBenchBranchEvaluator(Evaluator):
         Returns:
             qa_pairs        Question and answer pairs (with scores) from the evaluation
         """
+        logger.debug(locals())
         _, qa_pairs, _, error_rate = mt_bench_judgment.generate_judgment(
             self.model_name,
             self.judge_model_name,

--- a/src/instructlab/eval/mt_bench_answers.py
+++ b/src/instructlab/eval/mt_bench_answers.py
@@ -12,6 +12,7 @@ import shortuuid
 import tqdm
 
 # Local
+from .logger_config import setup_logger
 from .mt_bench_common import (
     bench_dir,
     chat_completion_openai,
@@ -19,9 +20,12 @@ from .mt_bench_common import (
     temperature_config,
 )
 
+logger = setup_logger(__name__)
+
 
 def reorg_answer_file(answer_file):
     """Sort by question id and de-duplication"""
+    logger.debug(locals())
     answers = {}
     with open(answer_file, "r", encoding="utf-8") as fin:
         for l in fin:
@@ -101,6 +105,7 @@ def generate_answers(
     bench_name="mt_bench",
 ):
     """Generate model answers to be judged"""
+    logger.debug(locals())
     openai_client = openai.OpenAI(base_url=model_api_base, api_key="NO_API_KEY")
 
     if data_dir is None:
@@ -115,11 +120,13 @@ def generate_answers(
     answer_file = f"{output_base_dir}/model_answer/{model_name}.jsonl"
     if os.path.isfile(answer_file):
         os.remove(answer_file)
+        logger.debug("Removing previous answer file: %s", answer_file)
 
     first_n = None
     first_n_env = os.environ.get("INSTRUCTLAB_EVAL_FIRST_N_QUESTIONS")
     if first_n_env:
         first_n = int(first_n_env)
+        logger.debug("INSTRUCTLAB_EVAL_FIRST_N_QUESTIONS=%s", first_n)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []

--- a/src/instructlab/eval/mt_bench_branch_generator.py
+++ b/src/instructlab/eval/mt_bench_branch_generator.py
@@ -11,10 +11,14 @@ import shortuuid
 import yaml
 
 # Local
+from .logger_config import setup_logger
 from .mt_bench_common import bench_dir
+
+logger = setup_logger(__name__)
 
 
 def get_file_paths(directory):
+    logger.debug(locals())
     file_paths = []
     for root, _, files in os.walk(directory):
         for file in files:
@@ -31,6 +35,7 @@ def read_qna(fn):
 
 def generate(judge_model_name, branch, taxonomy_dir, output_dir):
     """Create questions and reference answers from taxonomy"""
+    logger.debug(locals())
     restore_branch = None
     try:
         if branch is not None:
@@ -89,20 +94,21 @@ def generate(judge_model_name, branch, taxonomy_dir, output_dir):
                     }
                 )
 
-        print(f"generated {len(question_lst)} questions")
+        logger.debug("Generated %s questions", len(question_lst))
 
         output_base_dir = bench_dir(output_dir, "mt_bench_branch", branch)
         os.makedirs(output_base_dir, exist_ok=True)
         question_fn = "question.jsonl"
-        with open(
-            os.path.join(output_base_dir, question_fn), "w", encoding="utf-8"
-        ) as outfile:
+        question_file = os.path.join(output_base_dir, question_fn)
+        logger.debug("Generating question file: %s", question_file)
+        with open(question_file, "w", encoding="utf-8") as outfile:
             for entry in question_lst:
                 json.dump(entry, outfile)
                 outfile.write("\n")
 
         answer_file_dir = os.path.join(output_base_dir, "reference_answer")
         answer_file = os.path.join(answer_file_dir, f"{judge_model_name}.jsonl")
+        logger.debug("Generating answer file: %s", answer_file)
         os.makedirs(os.path.dirname(answer_file), exist_ok=True)
         with open(
             answer_file,

--- a/src/instructlab/eval/mt_bench_common.py
+++ b/src/instructlab/eval/mt_bench_common.py
@@ -16,6 +16,11 @@ import time
 from fastchat.model.model_adapter import get_conversation_template  # type: ignore
 import openai
 
+# Local
+from .logger_config import setup_logger
+
+logger = setup_logger(__name__)
+
 # API setting constants
 API_MAX_RETRY = 4
 API_RETRY_SLEEP = 4
@@ -84,6 +89,7 @@ def load_model_answers(answer_dir: str, model_name=None) -> dict:
     The return value is a python dict of type:
     Dict[model_name: str -> Dict[question_id: int -> answer: dict]]
     """
+    logger.debug(locals())
     model_answers = {}
     for root, _, files in os.walk(answer_dir):
         for filename in files:
@@ -98,6 +104,7 @@ def load_model_answers(answer_dir: str, model_name=None) -> dict:
                         answer[l["question_id"]] = l
                 model_answers[model_name or file_model_name] = answer
                 if model_name == file_model_name:
+                    logger.debug("Found answer file matching: %s", model_name)
                     break
     return model_answers
 
@@ -108,6 +115,7 @@ def load_judge_prompts(prompt_file: str) -> dict:
     The return value is a python dict of type:
     Dict[judge_name: str -> dict]
     """
+    logger.debug(locals())
     prompts = {}
     with open(prompt_file, encoding="utf-8") as fin:
         for line in fin:
@@ -163,6 +171,11 @@ def run_judge_single(
             rating = ast.literal_eval(match.groups()[0])
         else:
             rating = -1
+            logger.debug(
+                "Received invalid judgment for question %s with judgment: %s",
+                question["question_id"],
+                judgment,
+            )
     else:
         raise ValueError(
             f"invalid output format: {judge.prompt_template['output_format']}"
@@ -245,6 +258,8 @@ def chat_completion_openai(openai_client, model, conv, temperature, max_tokens) 
             if i == API_MAX_RETRY - 1:
                 # Print error on last try
                 print(type(e), e)
+            else:
+                logger.debug(e)
             time.sleep(API_RETRY_SLEEP)
 
     return output
@@ -272,6 +287,7 @@ def check_data(questions, model_answers, ref_answers, models, judges):
 
 
 def get_model_list(answer_dir):
+    logger.debug(locals())
     file_paths = glob.glob(f"{answer_dir}/*.jsonl")
     file_names = [os.path.splitext(os.path.basename(f))[0] for f in file_paths]
     return file_names


### PR DESCRIPTION
This PR is following the same pattern as the sdg library.  

Resolves: #54


Example output with log_level=DEBUG so far:

```
$ ilab model evaluate --model models/instructlab/granite-7b-lab --judge-model models/instructlab/granite-7b-lab --branch main --base-branch rc --base-model models/instructlab/granite-7b-lab --benchmark mt_bench_branch --taxonomy-path /home/ec2-user/taxonomy
===================using parameters ========================
model            : models/instructlab/granite-7b-lab
judge_model      : models/instructlab/granite-7b-lab
branch           : main
base_branch      : rc
base_model       : models/instructlab/granite-7b-lab
benchmark        : mt_bench_branch
taxonomy_path    : /home/ec2-user/taxonomy
output_dir       : eval_data
max_workers      : 40
few_shots        : 2
batch_size       : 5
sdg_path         : generated
tls_insecure     : False
tls_client_cert  : 
tls_client_key   : 
tls_client_passwd: 
============================================================
INFO 2024-07-08 18:24:53,464 utils.py:161: _init_num_threads NumExpr defaulting to 16 threads.
INFO 2024-07-08 18:24:53,579 config.py:58: <module> PyTorch version 2.3.0 available.
Generating questions and reference answers from qna files for branch main...
DEBUG 2024-07-08 18:25:24,446 mt_bench.py:117: gen_answers {'self': <instructlab.eval.mt_bench.MTBenchBranchEvaluator object at 0x7f9b59a71b10>, 'server_url': 'http://127.0.0.1:39335/v1'}
DEBUG 2024-07-08 18:25:24,446 mt_bench_branch_generator.py:38: generate {'judge_model_name': 'judge_model', 'branch': 'main', 'taxonomy_dir': '/home/ec2-user/taxonomy', 'output_dir': 'eval_data'}
DEBUG 2024-07-08 18:25:24,454 mt_bench_branch_generator.py:21: get_file_paths {'directory': '/home/ec2-user/taxonomy'}
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 147/147 [00:00<00:00, 172.32it/s]
DEBUG 2024-07-08 18:25:25,314 mt_bench_branch_generator.py:97: generate Generated 413 questions
DEBUG 2024-07-08 18:25:25,314 mt_bench_branch_generator.py:103: generate Generating question file: eval_data/mt_bench_branch/main/question.jsonl
DEBUG 2024-07-08 18:25:25,320 mt_bench_branch_generator.py:111: generate Generating answer file: eval_data/mt_bench_branch/main/reference_answer/judge_model.jsonl
DEBUG 2024-07-08 18:25:25,334 mt_bench_answers.py:108: generate_answers {'model_name': 'test_model', 'model_api_base': 'http://127.0.0.1:39335/v1', 'branch': 'main', 'output_dir': 'eval_data', 'data_dir': 'eval_data', 'question_begin': None, 'question_end': None, 'force_temperature': None, 'num_choices': 1, 'max_tokens': 1024, 'max_workers': 40, 'bench_name': 'mt_bench_branch'}
DEBUG 2024-07-08 18:25:25,362 mt_bench_answers.py:123: generate_answers Removing previous answer file: eval_data/mt_bench_branch/main/model_answer/test_model.jsonl
DEBUG 2024-07-08 18:25:25,362 mt_bench_answers.py:129: generate_answers INSTRUCTLAB_EVAL_FIRST_N_QUESTIONS=4
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:09<00:00,  2.40s/it]
DEBUG 2024-07-08 18:25:34,993 mt_bench_answers.py:28: reorg_answer_file {'answer_file': 'eval_data/mt_bench_branch/main/model_answer/test_model.jsonl'}
Generating questions and reference answers from qna files for branch rc...
DEBUG 2024-07-08 18:26:04,363 mt_bench.py:117: gen_answers {'self': <instructlab.eval.mt_bench.MTBenchBranchEvaluator object at 0x7f9a39dcd510>, 'server_url': 'http://127.0.0.1:54003/v1'}
DEBUG 2024-07-08 18:26:04,363 mt_bench_branch_generator.py:38: generate {'judge_model_name': 'judge_model', 'branch': 'rc', 'taxonomy_dir': '/home/ec2-user/taxonomy', 'output_dir': 'eval_data'}
DEBUG 2024-07-08 18:26:04,369 mt_bench_branch_generator.py:21: get_file_paths {'directory': '/home/ec2-user/taxonomy'}
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 147/147 [00:00<00:00, 172.53it/s]
DEBUG 2024-07-08 18:26:05,227 mt_bench_branch_generator.py:97: generate Generated 413 questions
DEBUG 2024-07-08 18:26:05,227 mt_bench_branch_generator.py:103: generate Generating question file: eval_data/mt_bench_branch/rc/question.jsonl
DEBUG 2024-07-08 18:26:05,235 mt_bench_branch_generator.py:111: generate Generating answer file: eval_data/mt_bench_branch/rc/reference_answer/judge_model.jsonl
DEBUG 2024-07-08 18:26:05,249 mt_bench_answers.py:108: generate_answers {'model_name': 'base_test_model', 'model_api_base': 'http://127.0.0.1:54003/v1', 'branch': 'rc', 'output_dir': 'eval_data', 'data_dir': 'eval_data', 'question_begin': None, 'question_end': None, 'force_temperature': None, 'num_choices': 1, 'max_tokens': 1024, 'max_workers': 40, 'bench_name': 'mt_bench_branch'}
DEBUG 2024-07-08 18:26:05,276 mt_bench_answers.py:123: generate_answers Removing previous answer file: eval_data/mt_bench_branch/rc/model_answer/base_test_model.jsonl
DEBUG 2024-07-08 18:26:05,277 mt_bench_answers.py:129: generate_answers INSTRUCTLAB_EVAL_FIRST_N_QUESTIONS=4
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:05<00:00,  1.45s/it]
DEBUG 2024-07-08 18:26:11,104 mt_bench_answers.py:28: reorg_answer_file {'answer_file': 'eval_data/mt_bench_branch/rc/model_answer/base_test_model.jsonl'}
Evaluating answers for branch main...
DEBUG 2024-07-08 18:26:40,956 mt_bench.py:144: judge_answers {'self': <instructlab.eval.mt_bench.MTBenchBranchEvaluator object at 0x7f9b59a71b10>, 'server_url': 'http://127.0.0.1:33371/v1'}
DEBUG 2024-07-08 18:26:40,957 mt_bench_judgment.py:276: generate_judgment {'model_name': 'test_model', 'judge_model_name': 'judge_model', 'model_api_base': 'http://127.0.0.1:33371/v1', 'bench_name': 'mt_bench_branch', 'output_dir': 'eval_data', 'data_dir': 'eval_data', 'branch': 'main', 'model_list': None, 'max_workers': 40, 'first_n': None}
DEBUG 2024-07-08 18:26:40,981 mt_bench_judgment.py:282: generate_judgment INSTRUCTLAB_EVAL_FIRST_N_QUESTIONS=4
DEBUG 2024-07-08 18:26:40,981 mt_bench_judgment.py:162: judge_model {'model_name': 'test_model', 'judge_model_name': 'judge_model', 'openai_client': <openai.OpenAI object at 0x7f9a39d16910>, 'branch': 'main', 'bench_name': 'mt_bench_branch', 'output_dir': 'eval_data', 'data_dir': 'eval_data', 'model_list': None, 'max_workers': 40, 'first_n': 4}
DEBUG 2024-07-08 18:26:40,983 mt_bench_common.py:92: load_model_answers {'answer_dir': 'eval_data/mt_bench_branch/main/model_answer', 'model_name': None}
DEBUG 2024-07-08 18:26:40,984 mt_bench_common.py:92: load_model_answers {'answer_dir': 'eval_data/mt_bench_branch/main/reference_answer', 'model_name': 'judge_model'}
DEBUG 2024-07-08 18:26:40,986 mt_bench_common.py:107: load_model_answers Found answer file matching: judge_model
DEBUG 2024-07-08 18:26:40,986 mt_bench_common.py:118: load_judge_prompts {'prompt_file': '/home/ec2-user/eval/src/instructlab/eval/data/mt_bench_branch/judge_prompts.jsonl'}
DEBUG 2024-07-08 18:26:40,987 mt_bench_common.py:285: get_model_list {'answer_dir': 'eval_data/mt_bench_branch/main/model_answer'}
DEBUG 2024-07-08 18:26:40,987 mt_bench_judgment.py:199: judge_model Removing previous judgment file: eval_data/mt_bench_branch/main/model_judgment/judge_model_single.jsonl
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:11<00:00,  2.75s/it]
DEBUG 2024-07-08 18:26:52,008 mt_bench_judgment.py:83: make_judgment {'question_file': 'eval_data/mt_bench_branch/main/question.jsonl', 'judgment_file': 'eval_data/mt_bench_branch/main/model_judgment/judge_model_single.jsonl', 'answer_file': 'eval_data/mt_bench_branch/main/model_answer/test_model.jsonl', 'bench_name': 'mt_bench_branch'}
DEBUG 2024-07-08 18:26:52,013 mt_bench_judgment.py:92: make_judgment #judgments: 4
DEBUG 2024-07-08 18:26:52,014 mt_bench_judgment.py:93: make_judgment #error free judgments: 3
DEBUG 2024-07-08 18:26:52,014 mt_bench_judgment.py:94: make_judgment error rate: 0.25
Evaluating answers for branch rc...
DEBUG 2024-07-08 18:26:52,025 mt_bench.py:144: judge_answers {'self': <instructlab.eval.mt_bench.MTBenchBranchEvaluator object at 0x7f9a39dcd510>, 'server_url': 'http://127.0.0.1:33371/v1'}
DEBUG 2024-07-08 18:26:52,026 mt_bench_judgment.py:276: generate_judgment {'model_name': 'base_test_model', 'judge_model_name': 'judge_model', 'model_api_base': 'http://127.0.0.1:33371/v1', 'bench_name': 'mt_bench_branch', 'output_dir': 'eval_data', 'data_dir': 'eval_data', 'branch': 'rc', 'model_list': None, 'max_workers': 40, 'first_n': None}
DEBUG 2024-07-08 18:26:52,050 mt_bench_judgment.py:282: generate_judgment INSTRUCTLAB_EVAL_FIRST_N_QUESTIONS=4
DEBUG 2024-07-08 18:26:52,050 mt_bench_judgment.py:162: judge_model {'model_name': 'base_test_model', 'judge_model_name': 'judge_model', 'openai_client': <openai.OpenAI object at 0x7f9a39d8f890>, 'branch': 'rc', 'bench_name': 'mt_bench_branch', 'output_dir': 'eval_data', 'data_dir': 'eval_data', 'model_list': None, 'max_workers': 40, 'first_n': 4}
DEBUG 2024-07-08 18:26:52,052 mt_bench_common.py:92: load_model_answers {'answer_dir': 'eval_data/mt_bench_branch/rc/model_answer', 'model_name': None}
DEBUG 2024-07-08 18:26:52,052 mt_bench_common.py:92: load_model_answers {'answer_dir': 'eval_data/mt_bench_branch/rc/reference_answer', 'model_name': 'judge_model'}
DEBUG 2024-07-08 18:26:52,056 mt_bench_common.py:107: load_model_answers Found answer file matching: judge_model
DEBUG 2024-07-08 18:26:52,056 mt_bench_common.py:118: load_judge_prompts {'prompt_file': '/home/ec2-user/eval/src/instructlab/eval/data/mt_bench_branch/judge_prompts.jsonl'}
DEBUG 2024-07-08 18:26:52,056 mt_bench_common.py:285: get_model_list {'answer_dir': 'eval_data/mt_bench_branch/rc/model_answer'}
DEBUG 2024-07-08 18:26:52,056 mt_bench_judgment.py:199: judge_model Removing previous judgment file: eval_data/mt_bench_branch/rc/model_judgment/judge_model_single.jsonl
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:20<00:00,  5.11s/it]
DEBUG 2024-07-08 18:27:12,498 mt_bench_judgment.py:83: make_judgment {'question_file': 'eval_data/mt_bench_branch/rc/question.jsonl', 'judgment_file': 'eval_data/mt_bench_branch/rc/model_judgment/judge_model_single.jsonl', 'answer_file': 'eval_data/mt_bench_branch/rc/model_answer/base_test_model.jsonl', 'bench_name': 'mt_bench_branch'}
DEBUG 2024-07-08 18:27:12,501 mt_bench_judgment.py:92: make_judgment #judgments: 4
DEBUG 2024-07-08 18:27:12,501 mt_bench_judgment.py:93: make_judgment #error free judgments: 4
DEBUG 2024-07-08 18:27:12,501 mt_bench_judgment.py:94: make_judgment error rate: 0.0
```