### PR TITLE
Parameterize ILAB_EVAL_MERGE_SYS_USR

### DIFF
--- a/src/instructlab/eval/mt_bench.py
+++ b/src/instructlab/eval/mt_bench.py
@@ -16,10 +16,11 @@ class MTBenchEvaluator(Evaluator):
     Child class of an Evaluator for Multi-turn Benchmark (MT-Bench)
 
     Attributes
-        model_name          Name of the model to evaluate
-        judge_model_name    Name of the judge model
-        output_dir          The directory to use for evaluation output
-        max_workers         Max parallel workers to run the evaluation with
+        model_name                  Name of the model to evaluate
+        judge_model_name            Name of the judge model
+        output_dir                  The directory to use for evaluation output
+        max_workers                 Max parallel workers to run the evaluation with
+        merge_system_user_message   Boolean indicating whether to merge system and user messages (required for Mistral based judges)
     """
 
     name = "mt_bench"
@@ -30,11 +31,13 @@ class MTBenchEvaluator(Evaluator):
         judge_model_name: str,
         output_dir: str = "eval_output",
         max_workers: int = 40,
+        merge_system_user_message: bool = False,
     ) -> None:
         self.model_name = model_name
         self.judge_model_name = judge_model_name
         self.output_dir = output_dir
         self.max_workers = max_workers
+        self.merge_system_user_message = merge_system_user_message
 
     def gen_answers(self, server_url) -> None:
         """
@@ -68,6 +71,7 @@ class MTBenchEvaluator(Evaluator):
             server_url,
             max_workers=self.max_workers,
             output_dir=self.output_dir,
+            merge_system_user_message=self.merge_system_user_message,
         )
 
 
@@ -76,12 +80,13 @@ class MTBenchBranchEvaluator(Evaluator):
     Child class of an Evaluator for MT-Bench-Branch Benchmark
 
     Attributes
-        model_name              Name of the model to evaluate
-        judge_model_name        Name of the judge model
-        taxonomy_git_repo_path  Taxonomy git repo path
-        branch                  Branch of taxonomy repo to eval QNAs against model
-        output_dir              The directory to use for evaluation output
-        max_workers             Max parallel workers to run the evaluation with
+        model_name                  Name of the model to evaluate
+        judge_model_name            Name of the judge model
+        taxonomy_git_repo_path      Taxonomy git repo path
+        branch                      Branch of taxonomy repo to eval QNAs against model
+        output_dir                  The directory to use for evaluation output
+        max_workers                 Max parallel workers to run the evaluation with
+        merge_system_user_message   Boolean indicating whether to merge system and user messages (required for Mistral based judges)
     """
 
     name = "mt_bench_branch"
@@ -94,6 +99,7 @@ class MTBenchBranchEvaluator(Evaluator):
         branch: str,
         output_dir: str = "eval_output",
         max_workers: int = 40,
+        merge_system_user_message: bool = False,
     ) -> None:
         self.model_name = model_name
         self.judge_model_name = judge_model_name
@@ -101,6 +107,7 @@ class MTBenchBranchEvaluator(Evaluator):
         self.branch = branch
         self.output_dir = output_dir
         self.max_workers = max_workers
+        self.merge_system_user_message = merge_system_user_message
 
     def gen_answers(self, server_url) -> None:
         """
@@ -144,5 +151,6 @@ class MTBenchBranchEvaluator(Evaluator):
             output_dir=self.output_dir,
             data_dir=self.output_dir,
             bench_name="mt_bench_branch",
+            merge_system_user_message=self.merge_system_user_message,
         )
         return qa_pairs, error_rate

--- a/src/instructlab/eval/mt_bench_answers.py
+++ b/src/instructlab/eval/mt_bench_answers.py
@@ -64,7 +64,11 @@ def get_answer(
             conv.append_message(conv.roles[1], None)
 
             output = chat_completion_openai(
-                openai_client, model, conv, temperature, max_tokens
+                openai_client,
+                model,
+                conv,
+                temperature,
+                max_tokens,
             )
 
             conv.update_last_message(output)

--- a/src/instructlab/eval/mt_bench_judgment.py
+++ b/src/instructlab/eval/mt_bench_judgment.py
@@ -150,6 +150,7 @@ def judge_model(
     model_list=None,
     max_workers=1,
     first_n=None,
+    merge_system_user_message=False,
 ):
     """Judge the model based on questions and reference answers"""
     package_data_dir = os.path.join(os.path.dirname(__file__), "data")
@@ -233,11 +234,21 @@ def judge_model(
     # Play matches
     if max_workers == 1:
         for match in tqdm(matches):
-            play_a_match_single(openai_client, match, output_file=output_file)
+            play_a_match_single(
+                openai_client,
+                match,
+                output_file=output_file,
+                merge_system_user_message=merge_system_user_message,
+            )
     else:
 
         def play_a_match_wrapper(match):
-            play_a_match_single(openai_client, match, output_file=output_file)
+            play_a_match_single(
+                openai_client,
+                match,
+                output_file=output_file,
+                merge_system_user_message=merge_system_user_message,
+            )
 
         np.random.seed(0)
         np.random.shuffle(matches)
@@ -262,6 +273,7 @@ def generate_judgment(
     model_list=None,
     max_workers=1,
     first_n=None,
+    merge_system_user_message=False,
 ):
     """Generate judgment with scores and qa_pairs for a model"""
     openai_client = openai.OpenAI(base_url=model_api_base, api_key="NO_API_KEY")
@@ -281,6 +293,7 @@ def generate_judgment(
         model_list=model_list,
         max_workers=max_workers,
         first_n=first_n,
+        merge_system_user_message=merge_system_user_message,
     )
 
     return make_judgment(


### PR DESCRIPTION
Parameterize ILAB_EVAL_MERGE_SYS_USR so it can be passed from the client.  The purpose of this option is to adopt to the prompt format of the prometheus model

Related to: #51 

Corresponding CLI change: https://github.com/instructlab/instructlab/pull/1630