### PR TITLE
[mt-bench] Add missing return val

### DIFF
--- a/tests/test_judge_answers.py
+++ b/tests/test_judge_answers.py
@@ -5,7 +5,7 @@ import pprint
 from instructlab.eval.mt_bench import MTBenchEvaluator
 
 mt_bench = MTBenchEvaluator("instructlab/granite-7b-lab", "instructlab/granite-7b-lab")
-overall_score, qa_pairs, turn_scores = mt_bench.judge_answers(
+overall_score, qa_pairs, turn_scores, error_rate = mt_bench.judge_answers(
     "http://localhost:8000/v1"
 )
 


### PR DESCRIPTION
`error_rate` was missing from the return list and erroring out