### PR TITLE
Inherit logging from caller rather than from vLLM

### DIFF
--- a/src/instructlab/eval/__init__.py
+++ b/src/instructlab/eval/__init__.py
@@ -1,0 +1,5 @@
+# Standard
+import os
+
+# Inherit logging from caller rather than from vLLM
+os.environ["VLLM_CONFIGURE_LOGGING"] = "0"


### PR DESCRIPTION
Without VLLM_CONFIGURE_LOGGING=0, vllm will reconfigure the root logger and the logging of the calling code will be affected.  With instructlab, the behavior was the logging was disabled after importing mmlu.

Resolves: #65