### PR TITLE
Don't set basicConfig from libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ GitPython>=3.1.42,<4.0.0
 shortuuid
 openai>=1.13.3,<2.0.0
 psutil
-rich==13.7.1
 torch
 transformers
 accelerate

--- a/src/instructlab/eval/logger_config.py
+++ b/src/instructlab/eval/logger_config.py
@@ -2,17 +2,8 @@
 # Standard
 import logging
 
-# Third Party
-from rich.logging import RichHandler
-
 
 def setup_logger(name):
     # Set up the logger
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(message)s",
-        datefmt="[%X]",
-        handlers=[RichHandler()],
-    )
     logger = logging.getLogger(name)
     return logger


### PR DESCRIPTION
This code was previously taken from sdg which was probably taken from backend code used in a different context.  Setting basicConfig should be left to the callers.