### PR TITLE
Revert "Bump sigstore/gh-action-sigstore-python from 2.1.1 to 3.0.0"

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -109,7 +109,7 @@ jobs:
                   path: dist
 
             - name: "Sigstore sign package"
-              uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
+              uses: sigstore/gh-action-sigstore-python@61f6a500bbfdd9a2a339cf033e5421951fbc1cd2 # v2.1.1
               with:
                   inputs: |
                       ./dist/*.tar.gz


### PR DESCRIPTION
Reverts instructlab/eval#70