### PR TITLE
feat: add new InvalidModelError and handling

### DIFF
--- a/src/instructlab/eval/exceptions.py
+++ b/src/instructlab/eval/exceptions.py
@@ -22,6 +22,23 @@ class ModelNotFoundError(EvalError):
         self.message = f"Model could not be found at {path}"
 
 
+class InvalidModelError(EvalError):
+    """
+    Error raised when model can be found but is invalid
+
+    Attributes
+        message     error message to be printed on raise
+        path        filepath of model location
+        reason      root cause for model invalidity
+    """
+
+    def __init__(self, path, reason) -> None:
+        super().__init__()
+        self.path = path
+        self.reason = reason
+        self.message = f"Model found at {path} but was invalid due to: {reason}"
+
+
 class InvalidGitRepoError(EvalError):
     """
     Error raised when taxonomy dir provided isn't a valid git repo

--- a/src/instructlab/eval/mmlu.py
+++ b/src/instructlab/eval/mmlu.py
@@ -12,6 +12,7 @@ import torch
 # First Party
 from instructlab.eval.evaluator import Evaluator
 from instructlab.eval.exceptions import (
+    InvalidModelError,
     InvalidTasksDirError,
     ModelNotFoundError,
     TasksDirNotFoundError,
@@ -158,6 +159,9 @@ class AbstractMMLUEvaluator(Evaluator):
                 ose
             ) or "does not appear to have a file named" in str(ose):
                 raise ModelNotFoundError(self.model_path) from ose
+            if "is not a valid JSON file" in str(ose):
+                reason = "Looked for valid JSON file but couldn't find one - are you pointing at a directory with a 'config.json'?"
+                raise InvalidModelError(self.model_path, reason) from ose
             raise
 
 


### PR DESCRIPTION
Passing a GGUF file via the CLI results in an unhandled exception that isn't super helpful.
```bash
(venv) [ec2-user@ip-10-0-9-221 instructlab]$ ilab model evaluate --benchmark mmlu_branch --model $ILAB_MODELS_DIR/granite-7b-lab-Q4_K_M.gguf --base-model instructlab/granite-7b-lab --tasks-dir ~/instructlab/tests/testdata/mmlu_branch
INFO 2024-07-23 01:33:21,599 numexpr.utils:161: NumExpr defaulting to 16 threads.
INFO 2024-07-23 01:33:21,717 datasets:58: PyTorch version 2.3.1 available.
INFO 2024-07-23 01:33:30,204 lm-eval:152: Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
INFO 2024-07-23 01:33:30,204 lm-eval:189: Initializing hf model, with arguments: {'pretrained': '/home/ec2-user/.local/share/instructlab/models/granite-7b-lab-Q4_K_M.gguf', 'dtype': 'bfloat16'}
INFO 2024-07-23 01:33:30,234 lm-eval:170: Using device 'cuda'
Traceback (most recent call last):
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/transformers/configuration_utils.py", line 722, in _get_config_dict
    config_dict = cls._dict_from_json_file(resolved_config_file)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/transformers/configuration_utils.py", line 825, in _dict_from_json_file
    text = reader.read()
           ^^^^^^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 329: invalid start byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ec2-user/instructlab/venv/bin/ilab", line 8, in <module>
    sys.exit(ilab())
             ^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/src/instructlab/clickext.py", line 214, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/src/instructlab/model/evaluate.py", line 660, in evaluate
    overall_score, individual_scores = evaluator.run()
                                       ^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/instructlab/eval/mmlu.py", line 252, in run
    results = self._run_mmlu()
              ^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/instructlab/eval/mmlu.py", line 127, in _run_mmlu
    mmlu_output = self._simple_evaluate_with_error_handling(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/instructlab/eval/mmlu.py", line 143, in _simple_evaluate_with_error_handling
    return simple_evaluate(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/lm_eval/utils.py", line 395, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/lm_eval/evaluator.py", line 192, in simple_evaluate
    lm = lm_eval.api.registry.get_model(model).create_from_arg_string(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/lm_eval/api/model.py", line 148, in create_from_arg_string
    return cls(**args, **args2)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/lm_eval/models/huggingface.py", line 196, in __init__
    self._get_config(
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/lm_eval/models/huggingface.py", line 470, in _get_config
    self._config = transformers.AutoConfig.from_pretrained(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/transformers/models/auto/configuration_auto.py", line 965, in from_pretrained
    config_dict, unused_kwargs = PretrainedConfig.get_config_dict(pretrained_model_name_or_path, **kwargs)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/transformers/configuration_utils.py", line 632, in get_config_dict
    config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/instructlab/venv/lib64/python3.11/site-packages/transformers/configuration_utils.py", line 726, in _get_config_dict
    raise EnvironmentError(
OSError: It looks like the config file at '/home/ec2-user/.local/share/instructlab/models/granite-7b-lab-Q4_K_M.gguf' is not a valid JSON file.
```
This PR adds a new exception type for when the desired JSON file cannot be found in the passed path.