### PR TITLE
Don't sleep on last retry attempt

### DIFF
--- a/src/instructlab/eval/mt_bench_common.py
+++ b/src/instructlab/eval/mt_bench_common.py
@@ -250,7 +250,6 @@ def play_a_match_single(
 def chat_completion_openai(
     openai_client, model, conv, temperature, max_tokens, merge_system_user_message=False
 ) -> str:
-    output = API_ERROR_OUTPUT
     for i in range(API_MAX_RETRY):
         try:
             messages = conv.to_openai_api_messages()
@@ -270,8 +269,7 @@ def chat_completion_openai(
                 temperature=temperature,
                 max_tokens=max_tokens,
             )
-            output = response.choices[0].message.content
-            break
+            return response.choices[0].message.content
         except openai.OpenAIError as e:
             if i == API_MAX_RETRY - 1:
                 # Print error on last try
@@ -280,7 +278,7 @@ def chat_completion_openai(
                 logger.debug(e)
             time.sleep(API_RETRY_SLEEP)
 
-    return output
+    return API_ERROR_OUTPUT
 
 
 def check_data(questions, model_answers, ref_answers, models, judges):

--- a/src/instructlab/eval/mt_bench_common.py
+++ b/src/instructlab/eval/mt_bench_common.py
@@ -274,8 +274,8 @@ def chat_completion_openai(
             if i == API_MAX_RETRY - 1:
                 # Print error on last try
                 print(type(e), e)
-            else:
-                logger.debug(e)
+                break
+            logger.debug(e)
             time.sleep(API_RETRY_SLEEP)
 
     return API_ERROR_OUTPUT


### PR DESCRIPTION
Completion attempt was retrying a number of times if API returned errors, sleeping for some time in between attempts. Due to a coding mistake, it was doing a final "sleep" after the final attempt; then returned error regardless. This sleep was redundant. The PR removes it.