### PR TITLE
tests: Fail when model is not served

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,21 @@
+# First Party
+from instructlab.eval.mt_bench_common import (
+    API_ERROR_OUTPUT,
+    bench_dir,
+    load_model_answers,
+)
+
+
+def _is_bad_answer(a):
+    return any(API_ERROR_OUTPUT in choice["turns"] for choice in a["choices"])
+
+
+def is_bad_answer_file(evaluator):
+    branch = getattr(evaluator, 'branch', None)
+    base_dir = bench_dir(evaluator.output_dir, evaluator.name, branch)
+    answer_dir = f"{base_dir}/model_answer"
+    for dataset in load_model_answers(answer_dir).values():
+        for answer in dataset.values():
+            if _is_bad_answer(answer):
+                return True
+    return False

--- a/tests/test_branch_gen_answers.py
+++ b/tests/test_branch_gen_answers.py
@@ -1,3 +1,9 @@
+# Standard
+import sys
+
+# Third Party
+from common import is_bad_answer_file
+
 # First Party
 from instructlab.eval.mt_bench import MTBenchBranchEvaluator
 
@@ -8,3 +14,6 @@ mt_bench_branch = MTBenchBranchEvaluator(
     "main",
 )
 mt_bench_branch.gen_answers("http://localhost:8000/v1")
+
+if is_bad_answer_file(mt_bench_branch):
+    sys.exit(1)

--- a/tests/test_gen_answers.py
+++ b/tests/test_gen_answers.py
@@ -1,5 +1,14 @@
+# Standard
+import sys
+
+# Third Party
+from common import is_bad_answer_file
+
 # First Party
 from instructlab.eval.mt_bench import MTBenchEvaluator
 
 mt_bench = MTBenchEvaluator("instructlab/granite-7b-lab", "instructlab/granite-7b-lab")
 mt_bench.gen_answers("http://localhost:8000/v1")
+
+if is_bad_answer_file(mt_bench):
+    sys.exit(1)


### PR DESCRIPTION
Parse the answers file and exit with non-zero return code when files contain an error flag choice.

This is a more limited fix (just for tests) while we are figuring out a better design to pass errors and error rates to the caller.

Closes: #77