### PR TITLE
Remove remaining print()s from the library

### DIFF
--- a/src/instructlab/eval/mt_bench_branch_generator.py
+++ b/src/instructlab/eval/mt_bench_branch_generator.py
@@ -64,7 +64,7 @@ def generate(judge_model_name, branch, taxonomy_dir, output_dir):
             examples = read_qna(qna_file_path)
             qna_file = qna_file_path[len(taxonomy_dir) + 1 :]
             if examples is None:
-                print(f"failed to load {qna_file}. skipping...")
+                logger.warning("failed to load %s. skipping...", qna_file)
                 continue
             for ex in examples:
                 q, a = ex.get("question"), ex.get("answer")

--- a/src/instructlab/eval/mt_bench_common.py
+++ b/src/instructlab/eval/mt_bench_common.py
@@ -272,8 +272,7 @@ def chat_completion_openai(
             return response.choices[0].message.content
         except openai.OpenAIError as e:
             if i == API_MAX_RETRY - 1:
-                # Print error on last try
-                print(type(e), e)
+                logger.error(e)
                 break
             logger.debug(e)
             time.sleep(API_RETRY_SLEEP)


### PR DESCRIPTION
Use logger for any messages produced instead.