### PR TITLE
fix: catch KeyError in mt_bench_branch

### DIFF
--- a/src/instructlab/eval/mt_bench_branch_generator.py
+++ b/src/instructlab/eval/mt_bench_branch_generator.py
@@ -56,8 +56,9 @@ def generate(judge_model_name, branch, taxonomy_dir, output_dir):
                 print(f"failed to load {qna_file}. skipping...")
                 continue
             for ex in examples:
-                q, a = ex["question"], ex["answer"]
+                q, a = ex.get("question"), ex.get("answer")
                 if q is None or a is None:
+                    logger.warning("Skipping malformed file %s", qna_file)
                     continue
 
                 c = ex["question"] if "context" in ex else None


### PR DESCRIPTION
If the keys for the questions and answers don't exist, the file should be ignored. Instead, it would currently crash with a stack trace. This will keep that from happening.