### PR TITLE
Allow for external serving to be used with mmlu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ transformers
 accelerate
 pandas
 pandas-stubs
-lm-eval>=0.4.3
+lm-eval>=0.4.4


### PR DESCRIPTION
Requires lm_eval >= 0.4.4

As implemented, if server_url is passed, it's used for external serving.  Otherwise the old logic is still applied.  Eventually we may want to remove the non external serving option.

Resolves: #50
Resolves: #68

Corresponding cli change: https://github.com/instructlab/instructlab/pull/2065
