### PR TITLE
Add optional auto tuning for max_workers

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -90,7 +90,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.9
+py-version=3.10
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/src/instructlab/eval/exceptions.py
+++ b/src/instructlab/eval/exceptions.py
@@ -39,6 +39,21 @@ class InvalidModelError(EvalError):
         self.message = f"Model found at {path} but was invalid due to: {reason}"
 
 
+class InvalidMaxWorkersError(EvalError):
+    """
+    Error raised when max_workers isn't an int or "auto"
+
+    Attributes
+        message         error message to be printed on raise
+        max_workers     max_workers specified
+    """
+
+    def __init__(self, max_workers) -> None:
+        super().__init__()
+        self.max_workers = max_workers
+        self.message = f"Invalid max_workers '{max_workers}' specified. Valid values are positive integers or 'auto'."
+
+
 class InvalidGitRepoError(EvalError):
     """
     Error raised when taxonomy dir provided isn't a valid git repo


### PR DESCRIPTION
To accomplish this, serving_gpus will also need to be passed by the caller.  This logic also removes the magic number if max_workers is not passed and relies on the cpu count instead.

Resolves: https://github.com/instructlab/eval/issues/95

More info on timings that influenced this algorithm: https://github.com/instructlab/instructlab/issues/2050