### PR TITLE
Dont retry on connection failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ scripts/infra/cloud-instance.sh ec2 ssh
 # Regardless of how you setup your instance
 git clone https://github.com/instructlab/taxonomy.git && pushd taxonomy && git branch rc && popd
 git clone --bare https://github.com/instructlab/eval.git && git clone eval.git/ && cd eval && git remote add syncrepo ../eval.git
-python -m venv venv
+python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 pip install -r requirements-dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,6 @@ from-first = true
 # import-heading-firstparty=First Party
 # import-heading-localfolder=Local
 known-local-folder = ["tuning"]
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/src/instructlab/eval/exceptions.py
+++ b/src/instructlab/eval/exceptions.py
@@ -107,3 +107,15 @@ class InvalidTasksDirError(EvalError):
         super().__init__()
         self.tasks_dir = tasks_dir
         self.message = f"Invalid Tasks Dir: {tasks_dir}"
+
+
+class OpenAIError(EvalError):
+    """
+    Error raised when reply retrieval from OpenAI API fails.
+    Attributes
+        message              error message to be printed on raise
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.message = "Failed to receive a reply from API."

--- a/src/instructlab/eval/exceptions.py
+++ b/src/instructlab/eval/exceptions.py
@@ -109,13 +109,13 @@ class InvalidTasksDirError(EvalError):
         self.message = f"Invalid Tasks Dir: {tasks_dir}"
 
 
-class OpenAIError(EvalError):
+class ModelServingAPIError(EvalError):
     """
-    Error raised when reply retrieval from OpenAI API fails.
+    Error raised when reply retrieval from model serving fails.
     Attributes
         message              error message to be printed on raise
     """
 
     def __init__(self) -> None:
         super().__init__()
-        self.message = "Failed to receive a reply from API."
+        self.message = "Failed to receive a reply from model serving API."


### PR DESCRIPTION
This is a continuation/replacement of https://github.com/instructlab/eval/pull/80

Resolves: #77

The approach of this separates errors into 3 buckets:

Fatal errors we retry and fail after max attempts (Ex: APIConnectionError, 404).  These cases don't have much hope of fixing themselves.
Errors which we record after max attempts (Ex: RateLimitError).  Failure on one try might not mean they are all going to fail.
Errors which we record after 1 occurrence (Ex: 400). Failure is request specific and retries aren't going to help.

Which allows the logic to fail fast when possible, not retry when it wouldn't help, and not catastrophically fail on isolated failures. 
