### PR TITLE
e2e: only run PR job if certain files are changed

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -28,6 +28,7 @@ pull_request_rules:
     # e2e workflow
     - or:
       - and:
+        # note this should match the triggering criteria in 'e2e-nvidia-t4-x1.yml'
         - check-success=e2e-workflow-complete
         - or:
           - files~=\.py$

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -3,10 +3,12 @@
 name: E2E (NVIDIA Tesla T4 x1)
 
 on:
+  # run against every merge commit to 'main' and release branches
   push:
     branches:
       - main
       - release-*
+  # only run on PRs that touch certain regex paths
   pull_request_target:
     types:
       - opened
@@ -15,6 +17,12 @@ on:
     branches:
       - main
       - release-*
+    paths:
+      # note this should match the merging criteria in 'mergify.yml'
+      - '**.py'
+      - 'pyproject.toml'
+      - 'requirements**.txt'
+      - '.github/workflows/e2e-nvidia-t4-x1.yml' # This workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
currently the E2E PR job runs on every single PR
this commit aligns the triggering criteria for
the job with the mergify automerge criteria