### PR TITLE
Update Python 3.12

### DIFF
--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -113,23 +113,23 @@ jobs:
       - name: Install system packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git python3.12 python3.12-devel
 
       - name: Install instructlab
         working-directory: ./instructlab
         run: |
           export PATH="/home/ec2-user/.local/bin:/usr/local/cuda/bin:$PATH"
-          python3.11 -m venv --upgrade-deps venv
+          python3.12 -m venv --upgrade-deps venv
           . venv/bin/activate
           nvidia-smi
-          python3.11 -m pip cache remove llama_cpp_python
+          python3.12 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
+          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.12 -m pip install .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed
-          python3.11 -m pip install packaging wheel setuptools-scm
-          python3.11 -m pip install .[cuda]
+          python3.12 -m pip install packaging wheel setuptools-scm
+          python3.12 -m pip install .[cuda]
         
       - name: Update instructlab-eval library
         working-directory: ./eval

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,10 +71,10 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
-      - name: Setup Python 3.11
+      - name: Setup Python 3.12
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
-          python-version: 3.11
+          python-version: 3.12
           cache: pip
           cache-dependency-path: |
             **/pyproject.toml

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 # py3-unit runs unit tests with 'python3'
-# py311-unit runs the same tests with 'python3.11'
+# py312-unit runs the same tests with 'python3.12'
 envlist = ruff, lint, mypy, spellcheck
 minversion = 4.4
 


### PR DESCRIPTION
Now that PyTorch 2.4 supports Python 3.12, This change attempts updating the default Python version to 3.12, jointly with the other repositories of the instructlab project.