### PR TITLE
chore: rename 'basic-workflow-tests' to 'e2e-custom'

### DIFF
--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -142,7 +142,7 @@ jobs:
         working-directory: ./instructlab
         run: |
           . venv/bin/activate
-          ./scripts/basic-workflow-tests.sh -msq
+          ./scripts/e2e-custom.sh -msq
 
   stop-runner:
     name: Stop external EC2 runner


### PR DESCRIPTION
the test file name is changing in the CLI repo ergo it must be changed here as well