### PR TITLE
Don't fail fast for unit and functional tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
     name: "test: ${{ matrix.python }} on ${{ matrix.platform }}"
     runs-on: "${{ matrix.platform }}"
     strategy:
+      fail-fast: false
       matrix:
         python:
           - "3.10"


### PR DESCRIPTION
Lets macos, ubuntu 3.10 and ubuntu 3.11 all finish even if one of the tests fails early.  There really isn't much downside in seeing if any of them pass.  Worst case they all fail early at the same place.

Similar made change for instructlab here: https://github.com/instructlab/instructlab/pull/2647