### PR TITLE
Add LongBench V2 benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = {file = ["requirements.txt"]}
 [tool.setuptools.dynamic.optional-dependencies]
 leaderboard = {file = ["requirements-leaderboard.txt"]}
 longbench = {file = ["requirements-longbench.txt"]}
+cuda = {file = ["requirements-cuda.txt"]}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ issues = "https://github.com/instructlab/eval/issues"
 "mt_bench" = "instructlab.eval.mt_bench:MTBenchEvaluator"
 "mt_bench_branch" = "instructlab.eval.mt_bench:MTBenchBranchEvaluator"
 "leaderboard_v2" = "instructlab.eval.leaderboard:LeaderboardV2Evaluator"
+"longbench" = "instructlab.eval.longbench:LongBenchEvaluator"
 
 [tool.setuptools_scm]
 version_file = "src/instructlab/eval/_version.py"
@@ -52,7 +53,10 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
-optional-dependencies = {leaderboard = {file = ["requirements-leaderboard.txt"]}}
+
+[tool.setuptools.dynamic.optional-dependencies]
+leaderboard = {file = ["requirements-leaderboard.txt"]}
+longbench = {file = ["requirements-longbench.txt"]}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,0 +1,2 @@
+vllm
+flash-attn

--- a/requirements-longbench.txt
+++ b/requirements-longbench.txt
@@ -1,3 +1,1 @@
 lm-eval[longbench]>=0.4.8
-vllm<=0.7.3
-flash-attn

--- a/requirements-longbench.txt
+++ b/requirements-longbench.txt
@@ -1,0 +1,3 @@
+lm-eval[longbench]>=0.4.8
+vllm<=0.7.3
+flash-attn

--- a/src/instructlab/eval/longbench.py
+++ b/src/instructlab/eval/longbench.py
@@ -190,7 +190,7 @@ class LongBenchEvaluator(Evaluator):
         else:
             eval_results["overall_score"] = 0.0
 
-        return dict(eval_results)
+        return t.cast(LongBenchResult, dict(eval_results))
 
     def run(
         self,
@@ -268,8 +268,9 @@ class LongBenchEvaluator(Evaluator):
             model_args = {
                 "pretrained": model_path,
                 "data_parallel_size": num_gpus,
-                **final_vllm_config,
             }
+            # Add vllm config properly
+            model_args.update(final_vllm_config)
 
             # Run evaluation
             results = simple_evaluate(

--- a/src/instructlab/eval/longbench.py
+++ b/src/instructlab/eval/longbench.py
@@ -79,28 +79,33 @@ TASK_METRICS = {
 }
 
 # Default configuration parameters
-DEFAULT_EVAL_CONFIG = {
-    "batch_size": "auto",
-    "apply_chat_template": True,
-    "fewshot_as_multiturn": True,
-    "confirm_run_unsafe_code": True,
-    "system_instruction": None,
-    "cache_requests": False,
-}
+# pylint: disable=use-dict-literal
+DEFAULT_EVAL_CONFIG = dict(
+    batch_size="auto",
+    apply_chat_template=True,
+    fewshot_as_multiturn=True,
+    confirm_run_unsafe_code=True,
+    system_instruction=None,
+    cache_requests=False,
+)
 
-DEFAULT_VLLM_CONFIG = {
-    "dtype": "float16",
-    "gpu_memory_utilization": 0.8,
-    "disable_custom_all_reduce": True,
-    "enforce_eager": False,
-    "max_model_len": 131072,
-}
+# vLLM-specific configuration - using longer context window than leaderboard
+# pylint: disable=use-dict-literal
+DEFAULT_VLLM_CONFIG = dict(
+    dtype="float16",
+    gpu_memory_utilization=0.8,
+    disable_custom_all_reduce=True,
+    enforce_eager=False,
+    max_model_len=131072,  # 128K context for LongBench
+)
 
-DEFAULT_OPENAI_CONFIG = {
-    "max_tokens": 768,
-    "temperature": 0.0,
-    "seed": 1337,
-}
+# OpenAI API configuration parameters
+# pylint: disable=use-dict-literal
+DEFAULT_OPENAI_CONFIG = dict(
+    max_tokens=768,
+    temperature=0.0,
+    seed=1337,
+)
 
 
 class LongBenchEvaluator(Evaluator):

--- a/src/instructlab/eval/longbench.py
+++ b/src/instructlab/eval/longbench.py
@@ -1,0 +1,198 @@
+# Standard
+import typing as t
+from collections import defaultdict
+import json
+import os
+
+# Third Party
+from lm_eval.evaluator import simple_evaluate
+from torch import cuda
+
+# Local
+from .evaluator import Evaluator
+
+class LongBenchResult(t.TypedDict):
+    """Dict containing averages for each task type and language"""
+    overall_score: float
+    en_multidoc: float
+    zh_multidoc: float
+    en_singledoc: float
+    zh_singledoc: float
+    en_summ: float
+    zh_summ: float
+    en_fewshot: float
+    zh_fewshot: float
+    en_synthetic: float
+    zh_synthetic: float
+    code_avg: float
+
+# Default configuration parameters
+DEFAULT_EVAL_CONFIG = {
+    "batch_size": "auto",
+    "apply_chat_template": True,
+    "fewshot_as_multiturn": True,
+    "confirm_run_unsafe_code": True,
+    "system_instruction": None,
+    "cache_requests": False,
+}
+
+DEFAULT_VLLM_CONFIG = {
+    "dtype": "float16",
+    "gpu_memory_utilization": 0.8,
+    "disable_custom_all_reduce": True,
+    "enforce_eager": False,
+    "max_model_len": 131072,
+}
+
+class LongBenchEvaluator(Evaluator):
+    """
+    Evaluator for LongBenchV2 benchmark.
+    
+    Attributes:
+        model_path: Path to the model to evaluate
+        num_gpus: Number of GPUs to use
+        output_file: Path to save results to
+        eval_config: Configuration for evaluation parameters
+        vllm_config: Configuration for vLLM-specific parameters
+    """
+    
+    name = "longbench"
+    
+    def __init__(
+        self,
+        model_path: str,
+        num_gpus: t.Optional[int] = None,
+        output_file: t.Optional[str] = None,
+        eval_config: t.Optional[t.Dict[str, t.Any]] = None,
+        vllm_config: t.Optional[t.Dict[str, t.Any]] = None,
+    ):
+        self.model_path = model_path
+        if not cuda.is_available():
+            raise ValueError("Running without CUDA is currently unsupported")
+            
+        self.num_gpus = num_gpus or cuda.device_count()
+        self.output_file = output_file
+        self.eval_config = eval_config or {}
+        self.vllm_config = vllm_config or {}
+        self._results: t.Optional[LongBenchResult] = None
+        self._lm_eval_results: t.Optional[t.Dict[str, t.Any]] = None
+
+    def _get_task_averages(self, results: dict) -> LongBenchResult:
+        """Calculate averages for each task type and language from raw results"""
+        eval_results = defaultdict(float)
+        results = results['results']
+        
+        # Multi-doc QA
+        eval_results['en_multidoc'] = (
+            results['longbench_hotpotqa']['qa_f1_score,none'] +
+            results['longbench_2wikimqa']['qa_f1_score,none'] +
+            results['longbench_musique']['qa_f1_score,none']
+        ) / 3
+
+        eval_results['zh_multidoc'] = results['longbench_dureader']['rouge_zh_score,none']
+
+        # Single-doc QA
+        eval_results['en_singledoc'] = (
+            results['longbench_multifieldqa_en']['qa_f1_score,none'] +
+            results['longbench_narrativeqa']['qa_f1_score,none'] +
+            results['longbench_qasper']['qa_f1_score,none']
+        ) / 3
+
+        eval_results['zh_singledoc'] = results['longbench_multifieldqa_zh']['qa_f1_zh_score,none']
+
+        # Summarization
+        eval_results['en_summ'] = (
+            results['longbench_gov_report']['rouge_score,none'] +
+            results['longbench_qmsum']['rouge_score,none'] +
+            results['longbench_multi_news']['rouge_score,none']
+        ) / 3
+
+        eval_results['zh_summ'] = results['longbench_vcsum']['rouge_zh_score,none']
+
+        # Few-shot
+        eval_results['en_fewshot'] = (
+            results['longbench_triviaqa']['qa_f1_score,none'] +
+            results['longbench_samsum']['rouge_score,none'] +
+            results['longbench_trec']['classification_score,none']
+        ) / 3
+
+        eval_results['zh_fewshot'] = results['longbench_lsht']['classification_score,none']
+
+        # Synthetic
+        eval_results['en_synthetic'] = (
+            results['longbench_passage_retrieval_en']['retrieval_score,none'] +
+            results['longbench_passage_count']['count_score,none']
+        ) / 2
+
+        eval_results['zh_synthetic'] = results['longbench_passage_retrieval_zh']['retrieval_zh_score,none']
+
+        # Code (language-agnostic)
+        eval_results['code_avg'] = (
+            results['longbench_lcc']['code_sim_score,none'] +
+            results['longbench_repobench-p']['code_sim_score,none']
+        ) / 2
+
+        # Calculate overall score
+        all_scores = [v for k, v in eval_results.items() if k != 'overall_score']
+        eval_results['overall_score'] = sum(all_scores) / len(all_scores)
+
+        return dict(eval_results)
+
+    def run(
+        self,
+        model_path: t.Optional[str] = None,
+        num_gpus: t.Optional[int] = None,
+        output_file: t.Optional[str] = None,
+        eval_config: t.Optional[t.Dict[str, t.Any]] = None,
+        vllm_config: t.Optional[t.Dict[str, t.Any]] = None,
+    ) -> LongBenchResult:
+        """Run the LongBench evaluation"""
+        model_path = model_path or self.model_path
+        num_gpus = num_gpus or self.num_gpus
+        output_file = output_file or self.output_file
+
+        # Merge configurations
+        final_eval_config = {**DEFAULT_EVAL_CONFIG, **self.eval_config, **(eval_config or {})}
+        final_vllm_config = {**DEFAULT_VLLM_CONFIG, **self.vllm_config, **(vllm_config or {})}
+
+        # Prepare model args
+        model_args = {
+            "pretrained": model_path,
+            "data_parallel_size": num_gpus,
+            **final_vllm_config,
+        }
+
+        # Extract system_instruction if provided
+        system_instruction = final_eval_config.pop("system_instruction", None)
+
+        # Run evaluation
+        results = simple_evaluate(
+            tasks=["longbench"],
+            model="vllm",
+            model_args=model_args,
+            system_instruction=system_instruction,
+            **final_eval_config,
+        )
+
+        self._lm_eval_results = results
+        self._results = self._get_task_averages(results)
+
+        if output_file:
+            self.save_to_file(output_file)
+
+        return self._results
+
+    @property
+    def results(self) -> t.Optional[LongBenchResult]:
+        """Returns the results of the most recent evaluation"""
+        return self._results
+
+    def save_to_file(self, output_file: t.Optional[str] = None) -> None:
+        """Save results to a JSON file"""
+        output_file = output_file or self.output_file
+        if not output_file:
+            raise ValueError("Output file path cannot be empty")
+
+        os.makedirs(os.path.dirname(output_file), exist_ok=True)
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(self._results, f, indent=2)

--- a/src/instructlab/eval/longbench.py
+++ b/src/instructlab/eval/longbench.py
@@ -243,7 +243,7 @@ class LongBenchEvaluator(Evaluator):
             # Optionally add max_length if you want
             if "max_length" in final_openai_config:
                 model_args["max_length"] = final_openai_config["max_length"]
-            
+
             if api_key:
                 model_args["api_key"] = api_key
 

--- a/src/instructlab/eval/longbench.py
+++ b/src/instructlab/eval/longbench.py
@@ -245,15 +245,15 @@ class LongBenchEvaluator(Evaluator):
                 "tokenizer": model_path,
                 "base_url": base_url,
             }
-            # Optionally add max_length if you want
+            # Optionally add max_length
             if "max_length" in final_openai_config:
-                model_args["max_length"] = final_openai_config["max_length"]
+                model_args["max_length"] = str(final_openai_config["max_length"])
 
             if api_key:
-                model_args["api_key"] = api_key
+                model_args["api_key"] = str(api_key)
 
             # Add any other openai_config keys if needed
-            # model_args.update(final_openai_config)  # Only if you want to pass more
+            # model_args.update(final_openai_config)
 
             # Run evaluation
             results = simple_evaluate(
@@ -267,10 +267,11 @@ class LongBenchEvaluator(Evaluator):
             # Prepare vLLM model args
             model_args = {
                 "pretrained": model_path,
-                "data_parallel_size": num_gpus,
+                "data_parallel_size": str(num_gpus),
             }
-            # Add vllm config properly
-            model_args.update(final_vllm_config)
+            # Add vllm config properly - convert all values to strings
+            string_vllm_config = {k: str(v) for k, v in final_vllm_config.items()}
+            model_args.update(string_vllm_config)
 
             # Run evaluation
             results = simple_evaluate(

--- a/src/instructlab/eval/longbench.py
+++ b/src/instructlab/eval/longbench.py
@@ -12,21 +12,21 @@ from torch import cuda
 from .evaluator import Evaluator
 
 
-class LongBenchResult(t.TypedDict):
+class LongBenchResult(t.TypedDict, total=False):
     """Dict containing averages for each task type and language"""
 
     overall_score: float
-    en_multidoc: t.NotRequired[float]
-    zh_multidoc: t.NotRequired[float]
-    en_singledoc: t.NotRequired[float]
-    zh_singledoc: t.NotRequired[float]
-    en_summ: t.NotRequired[float]
-    zh_summ: t.NotRequired[float]
-    en_fewshot: t.NotRequired[float]
-    zh_fewshot: t.NotRequired[float]
-    en_synthetic: t.NotRequired[float]
-    zh_synthetic: t.NotRequired[float]
-    code_avg: t.NotRequired[float]
+    en_multidoc: float
+    zh_multidoc: float
+    en_singledoc: float
+    zh_singledoc: float
+    en_summ: float
+    zh_summ: float
+    en_fewshot: float
+    zh_fewshot: float
+    en_synthetic: float
+    zh_synthetic: float
+    code_avg: float
 
 
 # Define task categories

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -7,7 +7,7 @@ from instructlab.eval.evaluator import Evaluator
 from instructlab.eval.leaderboard import LeaderboardV2Evaluator
 from instructlab.eval.mmlu import MMLUBranchEvaluator, MMLUEvaluator
 from instructlab.eval.mt_bench import MTBenchBranchEvaluator, MTBenchEvaluator
-
+from instructlab.eval.longbench import LongBenchEvaluator
 
 def test_evaluator_eps():
     expected = {
@@ -16,6 +16,7 @@ def test_evaluator_eps():
         "mt_bench": MTBenchEvaluator,
         "mt_bench_branch": MTBenchBranchEvaluator,
         "leaderboard_v2": LeaderboardV2Evaluator,
+        "longbench": LongBenchEvaluator,
     }
     eps = entry_points(group="instructlab.eval.evaluator")
     found = {}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,9 +5,10 @@ from importlib.metadata import entry_points
 # First Party
 from instructlab.eval.evaluator import Evaluator
 from instructlab.eval.leaderboard import LeaderboardV2Evaluator
+from instructlab.eval.longbench import LongBenchEvaluator
 from instructlab.eval.mmlu import MMLUBranchEvaluator, MMLUEvaluator
 from instructlab.eval.mt_bench import MTBenchBranchEvaluator, MTBenchEvaluator
-from instructlab.eval.longbench import LongBenchEvaluator
+
 
 def test_evaluator_eps():
     expected = {


### PR DESCRIPTION
Adding LongBench to eval options,

Install extras with:

`pip install instructlab-eval[longbench]`

Uses VLLM backend for serving the model for generation

Runs like so:

```
evaluator = LongBenchEvaluator(
    model_path="path/to/model",
    num_gpus=N,
    output_file="path/to/results.json",
    eval_config={"batch_size": "auto"},
    vllm_config={"max_model_len": max_len}
)

results = evaluator.run()  # Returns LongBenchResult
```

Output json looks like so:

```
{
  "en_multidoc": 0.5424139838230786,
  "zh_multidoc": 0.24335639081098673,
  "en_singledoc": 0.4233139199560039,
  "zh_singledoc": 0.46157875457875464,
  "en_summ": 0.27244809337990245,
  "zh_summ": 0.1359562304911904,
  "en_fewshot": 0.45692449627485754,
  "zh_fewshot": 0.24416666666666667,
  "en_synthetic": 0.3799285714285714,
  "zh_synthetic": 0.4775,
  "code_avg": 0.30225,
  "overall_score": 0.3581670097645466
}
```