### PR TITLE
deps: Bump minimum required Python version to 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.10"
           - "3.11"
         platform:
           - "ubuntu-latest"

--- a/.pylintrc
+++ b/.pylintrc
@@ -90,7 +90,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.11
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ A teacher model is used to generate new multiple choice questions based on the k
 
 ## Development
 
-> **⚠️ Note:** Must use Python version 3.10 or later.
+> **⚠️ Note:** Must use Python version 3.11 or later.
 
 ### Set up your dev environment
 
 The following tools are required:
 
 - [`git`](https://git-scm.com)
-- [`python`](https://www.python.org) (v3.10 or v3.11)
+- [`python`](https://www.python.org) (v3.11)
 - [`pip`](https://pypi.org/project/pip/) (v23.0+)
 - [`bash`](https://www.gnu.org/software/bash/) (v5+, for functional tests)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 description = "Evaluation"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
@@ -22,8 +22,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/tox.ini
+++ b/tox.ini
@@ -103,4 +103,3 @@ passenv =
 [gh]
 python =
     3.11 = py311-{unitcov, functional}
-    3.10 = py310-{unitcov, functional}


### PR DESCRIPTION
## Overview

In our core repo, we require Python >=3.11: https://github.com/instructlab/instructlab/blob/main/pyproject.toml#L13

In this repo, however, we currently require Python >=3.9, and we are only testing against Python 3.10 and 3.11 in the CI. Therefore, we should ensure consistency in terms of Python version support throughout our GitHub org.

## Proposed Changes
This bump includes updates to documentation, Git workflows, test configs, etc.