### PR TITLE
fix: Require medium and large E2E jobs to use constraints-dev.txt to unblock jobs

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -112,19 +112,20 @@ jobs:
         working-directory: ./instructlab
         run: |
           export CUDA_HOME="/usr/local/cuda"
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64"
           export PATH="$PATH:$CUDA_HOME/bin"
           python3.11 -m venv --upgrade-deps venv
           . venv/bin/activate
           nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install -v .
+          pip_install="python3.11 -m pip install -v -c constraints-dev.txt"
+          CMAKE_ARGS="-DGGML_CUDA=on" $pip_install .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed
-          python3.11 -m pip install -v packaging wheel setuptools-scm
-          python3.11 -m pip install -v .[cuda] -r requirements-vllm-cuda.txt
+          $pip_install packaging wheel setuptools-scm
+          $pip_install .[cuda] -r requirements-vllm-cuda.txt
         
       - name: Update instructlab-eval library
         working-directory: ./eval

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -143,19 +143,20 @@ jobs:
         working-directory: ./instructlab
         run: |
           export CUDA_HOME="/usr/local/cuda"
-          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64"
           export PATH="$PATH:$CUDA_HOME/bin"
           python3.11 -m venv --upgrade-deps venv
           . venv/bin/activate
           nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
+          pip_install="python3.11 -m pip install -v -c constraints-dev.txt"
+          CMAKE_ARGS="-DGGML_CUDA=on" $pip_install .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed
-          python3.11 -m pip install packaging wheel setuptools-scm
-          python3.11 -m pip install .[cuda] -r requirements-vllm-cuda.txt
+          $pip_install packaging wheel setuptools-scm
+          $pip_install .[cuda] -r requirements-vllm-cuda.txt
 
       - name: Update instructlab-eval library
         working-directory: ./eval


### PR DESCRIPTION
## Overview 

In the core repo, we are now using a `constraints-dev.txt` file to constrain our Python dependencies in the CI: https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml#L175

This means our dependencies in `requirements*.txt` are actually uncapped and the constraints file are restricting the versions we run in the CI.

In this repo, we are pulling the E2E workflow from the core repo without actually passing in `-c constraints-dev.txt`. Therefore, we're running our E2E tests against newer package versions than we want in some situations.

As an example, we see PyTorch-induced errors like this below because the core repo requires `torch==2.6.0`, but this repo is not constraining the version:
<img width="1144" alt="Screenshot 2025-05-15 at 9 57 32 AM" src="https://github.com/user-attachments/assets/cb444b32-eed1-4c29-872c-1e5582e2d02f" />
(Source: https://github.com/instructlab/eval/actions/runs/15044193998)