### PR TITLE
ci: stop reporting results to slack

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -214,34 +214,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Post job results to Slack if the workflow failed
-        if: failure() && steps.check_pr.outputs.is_pr == 'false'
-        id: slack-report-failure
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          token: ${{ secrets.SON_OF_JEEVES_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            # Slack channel id, channel name, or user id to post message.
-            # See also: https://api.slack.com/methods/chat.postMessage#channels
-            # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
-            channel: 'e2e-ci-results'
-            text: "*e2e-nvidia-l40s-x4* job in *${{ github.repository }}* running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed *with failures* :meow_sad-rain: | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-      - name: Post job results to Slack if the workflow succeeded
-        if: success() && steps.check_pr.outputs.is_pr == 'false'
-        id: slack-report-success
-        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
-        with:
-          token: ${{ secrets.SON_OF_JEEVES_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            # Slack channel id, channel name, or user id to post message.
-            # See also: https://api.slack.com/methods/chat.postMessage#channels
-            # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
-            channel: 'e2e-ci-results'
-            text: "*e2e-nvidia-l40s-x4* job in *${{ github.repository }}* running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed *successfully* :meow_party: | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
       - name: Send Discord notification for failure
         if: failure() && steps.check_pr.outputs.is_pr == 'false'
         uses: sarisia/actions-status-discord@5ddd3b114a98457dd80a39b2f00b6a998cd69008 # v1.15.3


### PR DESCRIPTION
Stop reporting CI results to Slack. This simplifies our e2e job definitions and removes a dependency on Slack. Most developers have moved to Discord.

Related: https://github.com/instructlab/instructlab/issues/3441