### PR TITLE
chore: Remove python 3.10 remnants

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -10,7 +10,7 @@ All unit tests currently live in the `tests/` directory and are run with [pytest
 
 To run the unit tests, you can run `tox -e unit` or `tox -e unitcov` if you want to generate coverage metrics as well.
 
-In CI, the tests are run with Python 3.10 - 3.11 on Ubuntu and MacOS runners - you can see the details [here](https://github.com/instructlab/eval/blob/main/.github/workflows/test.yml)
+In CI, the tests are run with Python 3.11 on Ubuntu and MacOS runners - you can see the details [here](https://github.com/instructlab/eval/blob/main/.github/workflows/test.yml)
 
 ## Functional tests
 
@@ -20,7 +20,7 @@ The functional test script is Shell-based and can be found at `scripts/functiona
 
 To run the functional tests, you can run `tox -e functional`.
 
-In CI, the tests are run with Python 3.10 - 3.11 on Ubuntu and MacOS runners - you can see the details [here](https://github.com/instructlab/eval/blob/main/.github/workflows/test.yml)
+In CI, the tests are run with Python 3.11 on Ubuntu and MacOS runners - you can see the details [here](https://github.com/instructlab/eval/blob/main/.github/workflows/test.yml)
 
 ## End-to-end (E2E) tests
 

--- a/requirements-leaderboard.txt
+++ b/requirements-leaderboard.txt
@@ -3,8 +3,3 @@ lm-eval[ifeval,vllm,math,sentencepiece]>=0.4.4
 # vLLM 0.8.3 + torch 2.6.0 doesn't work when running vLLM on granite-3.1-8b-instruct
 vllm<=0.7.3
 torch<=2.5.1
-
-# XXX(osilkin): We use StrEnum in leaderboard, but Python3.10 doesn't have it as part of
-#               the standard library, so we have to install it from the older library.
-strenum>=0.4.15; python_version < '3.11'
-typing-extensions>=4.0.0; python_version < '3.11'


### PR DESCRIPTION
It's not supported anymore.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
