### PR TITLE
add DCO.txt and remove mergify DCO requirement

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,7 +11,6 @@ pull_request_rules:
     - label!=hold
     - label!=do-not-merge
     - label!=needs-rebase
-    - check-success=DCO
 
     # The files conditions regex should match the globs in workflow files
     # If workflow configuration files in .github/ are changed, the actionlint check must pass

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -263,3 +263,7 @@ eval_output/
             └── instructlab
                 └── granite-7b-lab.jsonl
 ```
+
+## Developer Certificate of Origin
+
+When you make a contribution to InstructLab eval, you implicitly agree to the Developer Certificate of Origin terms as set in `DCO.txt` at the root of this repository.


### PR DESCRIPTION
Add the contents of https://developercertificate.org/ to `DCO.txt` at the root of this repository.

Explain to contributors that new submissions imply acceptance of the DCO.

Related: instructlab/dev-docs#192