### PR TITLE
chore: Uncap some requirements dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-GitPython>=3.1.42,<4.0.0
+GitPython>=3.1.42
 shortuuid
-openai>=1.13.3,<2.0.0
+openai>=1.13.3
 psutil
 torch
 transformers


### PR DESCRIPTION
There are still more caps in leaderboard requirements. These will
require a separate consideration.

Note: these uncaps don't change actual constraints used since they were
merely defensive and covered non-existing versions.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
